### PR TITLE
Add support for payment source address [DO NOT MERGE]

### DIFF
--- a/app/models/solidus/gateway/braintree_gateway.rb
+++ b/app/models/solidus/gateway/braintree_gateway.rb
@@ -57,7 +57,7 @@ module Solidus
       return if source.gateway_customer_profile_id.present? || payment.payment_method_nonce.nil?
 
       user = payment.order.user
-      address = payment.order.bill_address.try(:active_merchant_hash)
+      address = payment.source.address.try(:active_merchant_hash) || payment.order.bill_address.try(:active_merchant_hash)
 
       params = {
         first_name: source.first_name,

--- a/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/billing_address_to_braintree/fallsback_to_order_billing_address.yml
+++ b/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/billing_address_to_braintree/fallsback_to_order_billing_address.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <first-name>Card</first-name>
+          <last-name>Holder</last-name>
+          <email>ole_stoltenberg@hermann.co.uk</email>
+          <credit-card>
+            <cardholder-name>Card Holder</cardholder-name>
+            <billing-address>
+              <street-address>10 Lovely Street</street-address>
+              <extended-address>Northwest</extended-address>
+              <locality>Herndon</locality>
+              <region>AL</region>
+              <country-code-alpha2>US</country-code-alpha2>
+              <postal-code>35005</postal-code>
+            </billing-address>
+            <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+            <options>
+              <verify-card type="boolean">true</verify-card>
+            </options>
+          </credit-card>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.46.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 29 Jul 2015 14:21:54 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      X-Authentication:
+      - basic_auth
+      Strict-Transport-Security:
+      - max-age=31536000
+      - max-age=31536000; includeSubDomains
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"df0f4322caeb43391425bca1014fc1d0"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 47c94ebd1b9247b6d3d38d8cc95bcf2e
+      X-Runtime:
+      - '0.729711'
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAILhuFUAA7RYS2/bOBC+51cYviuSX4kTKMoGu9gWi7aXJnvoJaCksc21
+        RKokZcf99R1SL8qyHT+yBwPmzDej4bwl//EtTXorEJJy9tAfXHv9HrCIx5TN
+        H/ovz3870/5jcOVHuVQ8BRFc9Xo+jYPJZDq9G03ufBcPmoa8aEGYcvD8K2ST
+        za+fd+p2na7fxkPftbkaPaNCKoeRFII/iYh91yJofkKq02eexCB8t6FofsTT
+        jLBNj9Hkoa9EDn3X0CElNAl4Aq9obqKAhSDmfyxApISx64hf50vfLUAani04
+        g46SGXnr0NYQSqq62EgAURA7RPXUJoOHfoxHRVPoB0NvMHG8W2d49zwY3w8H
+        95PxD99tBIx8nsWnyTcCxfNNXJwZhSSWtUkxVU6EfpWlUiIE2fQ1t80vKEgL
+        aZJgxB0SxwKkrOhFrFeLKsolrUoGp5UINrXBNoHd9l0JqAO7h78n1CVXKgGg
+        arsHXu8LX0Gy6X03DN/dAjSS8IbpEWtPlqxvXKjFGiQKdXiWuTwiCVWb4DMI
+        FnOGmVlRGpCAOZZT8PTFd8u/DS/jUpHEwRKDYDTxvInv2iT74jlTYmPIDkmy
+        BRkGL9/Rzzvoh6RGKPW0S2y0T4zlGEYaBdOxtyVXcbqCpjRfGNZIjL7HFJU9
+        Pus9GThptFQVXElfVj6llguLyOhw95QAlgYLxt5gOJ1qTB1JX9ePox8X/Eul
+        vmF9thEL076aTter+tk2sxbiqW6WlCTozSXja6adV9MaWOFPPnOolDlhEbTD
+        bDNqocu9fXztN0hdIEoXgcneDrXCxxBS1Vy6ODbMGcmTyu6QY4snrB/ofqCh
+        htmAc4GRcrD08kTbbynd5lQi8JZRYexxUs7UIhgMdRvYIu5Ab4AI9N7Qa8EN
+        tYXGstiyfUYSCaWUZckCSKIWmB7QmG3RKhhNyRycXCTBQqlM3rsukRKUvA4F
+        oUw3vTlecE02OPVSNyObFJh6TUEtePya8Dl3V5i21xmbPwJbUcGZBjxIwuKQ
+        v2HDr/XXT8R00gUSErZsTGtRK6jp6eNgMJ0Oysk9rnloiuCJld0VoQYIyAjm
+        0TeOvPJ/xZN5KCNBM+3k9nCrh4Kv+BJYcHOzmoY3vlucKl7O6M/ctLHQJCte
+        meLsFME4Ho0n0S2Mw8Hgdjgi8RBms0kY35LQG+APe8Y+0Vr3B3ShFbCUOzJe
+        7kmWmm9JCDSjKKVd474DashmfBKVy6DgQ6zHpSHYmGi1woKRGeqHYkZ9xTLu
+        EG0RspIOCMFFG7N7hpd4awh2H3cYsK2qPfN3azuIsRWWZYSI/yAyxY1NUXK2
+        9zL1rksi04x1T5SYyGCtwRbLFs0Ej9Cabb/hWuN5uhh2c9/RoHCbCZ4y5Kx0
+        hPchbC1o1mi8WgvVXvyaRdGmHbHkGdA7i16Ra4eWvTJjz1z4jPR5S19h/hGL
+        nwEeWP6KEB25AJYOuWC9staadkV33wBKzoHeWSfAznXIjvHuxl89+721qY7U
+        CQO5K/P+WK7sOW1LsW5x6mpXiv6PI6hKsP0DtEQct2OU4EN7WQU5eeGq/HjU
+        tlvd653NoYQdv6fURpy+S9eu5nEemT7eWNXQWpW4p+o+5h3oY/YPo0dQuXSQ
+        Q7b9ikPhx19fvedPnz7/czvcHg0mUyIqTe8rpo1OlpLS8sSOJ+jVprujtKll
+        R+54skUwIL9s4bDzA8j2G17nE8cJLzmHJ9/hmXdo2p07586acEfMtv1T7ch5
+        ds7njLM+Zpz5KeOSSfshL9YXly/utU1Y6wPgsUnd4Oo3AAAA//8DAJId6XTx
+        FQAA
+    http_version: 
+  recorded_at: Wed, 29 Jul 2015 14:21:57 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/with_a_user_with_an_invalid_email/fails.yml
+++ b/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/with_a_user_with_an_invalid_email/fails.yml
@@ -44,7 +44,7 @@ http_interactions:
       message: Unprocessable Entity
     headers:
       Date:
-      - Tue, 28 Jul 2015 20:50:44 GMT
+      - Wed, 29 Jul 2015 14:21:50 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -67,15 +67,15 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - afc56437112eb4fd6ccb136fd0de1915
+      - f4990da0924b7ad8b18309e8c9d9a401
       X-Runtime:
-      - '0.095276'
+      - '0.124144'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIACTrt1UAA5RUTW/bMAy991cIvitOtnXoQVE3DBt6KHbpeh4Ui06E6cOj
+        H4sIAH7huFUAA5RUTW/bMAy991cIvitOtnXoQVE3DBt6KHbpeh4Ui06E6cOj
         5Cz+96Pd+CtJ1+wmvkdSFKlHcX9wlu0Bowl+na0Wy4yBL4I2frvOnn9843fZ
         vbwRqjIcEANyhFgFH0HeMCY6KLbHwWCpqWCdKUTVZPmRKuqYggN8MS/79lzP
         jnabIGiQd6uPyw8i785TUqWEZlMnOOaLjdsEm0lwyliRD/QsyEGMagvya+vE
@@ -88,5 +88,5 @@ http_interactions:
         LKFK9Kh5a2ilmbJ5GXzCmpJMkUlxZ8FCw94UwCOVSgynfeCNXWdtlplaSlS1
         ppqw2Ckq7rLfFdIZ9fKfS4lW24W1/BcAAP//AwDqfmK70wUAAA==
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 20:50:46 GMT
+  recorded_at: Wed, 29 Jul 2015 14:21:54 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/with_a_valid_credit_card/decline/fails.yml
+++ b/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/with_a_valid_credit_card/decline/fails.yml
@@ -10,7 +10,7 @@ http_interactions:
         <customer>
           <first-name>Card</first-name>
           <last-name>Holder</last-name>
-          <email>jude_brekke@bradtkekshlerin.co.uk</email>
+          <email>price@kutch.com</email>
           <credit-card>
             <cardholder-name>Card Holder</cardholder-name>
             <billing-address>
@@ -44,7 +44,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 28 Jul 2015 20:50:55 GMT
+      - Wed, 29 Jul 2015 14:22:05 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -65,51 +65,50 @@ http_interactions:
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Etag:
-      - '"c225bcb8cbe400ddc3847ca05754a39b"'
+      - '"e8dfd726a09c02caa4d8b270dbf4c686"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 0c6fb0c7d05ec71412a5c02bf46935f8
+      - cad3bada04dca8f385bcfa9ee89563f0
       X-Runtime:
-      - '2.729469'
+      - '1.431732'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAC/rt1UAA7RYW4/aOhB+769AvGcTboWtsulZHemoDz3VkXqT+lI58QAu
-        iZ3aDgv99R07N4cAC2yPtCvhmW+c8XguXxK+3WXpYAtSMcEfhqO7YDgAngjK
-        +Oph+PnTP95i+DZ6FSaF0iIDGb0aDEJGo/Fsfn8/m70OfVwYGeqSNeHaw/Wv
-        mM/2v37e6/lT9rSbjkPf1Rr0kkmlPU4yiP4mkoa+IzD6lNSrdyKlIEO/lRh9
-        IrKc8P2As/RhqGUBQ9/KISMsjX4UFL7HEjYb+CuWhOoNbNQ6Bcn4XSLuik3o
-        l0Bjkq8Fh95GS7LryZ4gVkz3sYkEooF6RA/0PoeHIcWlZhkMo3EwmnnB3Bsv
-        Po2DNzP8m30L/dbA2hc5vc6+NSifb+/GWzJIqWpcokx7CcZWVZsSKcl+aLRd
-        fSlBWczSFG/dI5RKUKqWl/edb+qbrmR1QnidZHClLba93MPYVYDmck/oT1x3
-        pVVaAujG71EweC+2kO4HH60i9A8ArSXsNHBqIlmpPgip10+g0Kinc9wVCUmZ
-        3kfvQHIqOGZnLWlBElZYUtHj+9Cvfra6XChNUg/LDKLJLAhmoe+K3IMXXMu9
-        FXskzddkHH3+iHE+Ij9nNUGrx2Nmk1NmvMBrZEm0mAYHdrWmb2jL8zPHGqEY
-        e0xRNRDLwaOFk3aXuopr65eVT7XLC4vI7uGfKAEsDR5Ng9F4sTCY5iZDUz+e
-        eVz0hSlzwmbtIta2hbXdblD3tENlYyQy0zAZSTGaGy6euAleI2thZTzF0mNK
-        FYQn0L1mV9EYvTzal9d+izQFok0R2OztSWs8hZjp9tDlslUuSZHWfsdCpED4
-        MDL9wECtsgUXEm/Kw9IrUuO/s+mhpjaBXc6k9cfLBNfraDQ2beBAeAS9ByIx
-        euOgA7fSDhrL4sD3JUkVVFaOJ2sgqV5jekDrtiOrYSwjK/AKmUZrrXP1xveJ
-        UqDVHQ49xk3TW+EBn8gep17m52SfAdffM9BrQb+nYiX8LabtXc5Xb4FvmRTc
-        AB4U4TQWO2z4zf7NEzGdTIHEhG9a1zrSGmp7+jQaLRajanpPGx26IkXqZHct
-        aAAScoJ59EGgrvpd61QRq0Sy3AS5O9yaoRBqsQEs2fs5pavQL1e1ruDsZ2Hb
-        WGyTFY/McHbKaEon01kyh2k8Gs3HE0LHsFzOYjoncTDCf+wZp0ybvf9AF9oC
-        z4Sn6OZEsjR6x0KiG2UpHRv3PVArtuOT6EJFpR6oGZdW4GKS7RYLRuW4P5Qz
-        6l8s457QNSFb5YGUQnYxx2d4hXeGYP9x5wGHW3Vn/vHdzmLcDasyQsQPSGxx
-        Y1NUgp88TMN3SWKbsemJChMZHCrsqFzTXIoEvTmMG9KaIDDFcFz7zA4a2Uz0
-        mKNma274FMLdBd2KJ9nu9aJL/Fqi6MouIHkW9AzRK3PtHNmrMvZGwmetbyN9
-        pfsXED8LPEP+yiu6kABWAXkBvXJoTbei+28AleZM72wS4Cgdcu/4eOOvn/0c
-        bWpu6oqB3Ld5fizX/lzHUpxTXEvtKtP/cQTVCXZ6gFaIyzhGBT7Hy2rI1YSr
-        juNFbLc+1zPMoYJdzlMaJ67n0k2oBS0S28dbr1pZpxJPVN11rHx84h3oz/AP
-        u49kauOhhhzGlUaTb/OvwfTrx9f/fflyOBpspiRM2d5XThuTLJWkE4kjTzDU
-        ps9RutKqI/ci2RFYUFi1cDj6AeTwDa/3ieOKl5zzk+/8zDs37W6dczdNuAtm
-        2+mpduE8u+Vzxk0fM278lPGSSftHXqxfXL7Ia9trbRaAyzZ1o1e/AQAA//8D
-        AHYdQ3v1FQAA
+        H4sIAI3huFUAA7RYS2/bOBC+91cYviuSZXvtFIq6wRaLHtoCu30ceikocWyz
+        kUiVpJy4v36H1IuybMd2uocA4cw31Gienxy9ecqz0RakYoLfjSc3wXgEPBWU
+        8fXd+Mvnv73l+E38KkpLpUUOMn41GkWMxotwNl1OF7eRjwcjQ126IVx7eP6V
+        8Pnu189bvXjMH59mYeS7WoNeMam0x0kO8V9E0sh3BEafkeb0TmQUZOR3EqNP
+        RV4Qvhtxlt2NtSxh7Fs55IRlcSFZCn8+lDrd3CAy8iuxARQbwWFgtiJPA9kj
+        JIrpITaVQDRQj+iR3hVwN6Z41CyHcRwGk7kXLLzw9vNk9joMXwfzb5HfGVj7
+        sqCX2XcG1fNtJrwVg4yq1iXKtJdiJFV9KZGS7MZG29dXEpQlLMswxx6hVIJS
+        jbzK7ips8lrLmvR7vdS70g7bpXI/djWgTeUR/ZHk1lqlJYBu/Z4Eo/diC9lu
+        9MkqIn8P0FnCkwZOTSRr1Uch9eYRFBoNdI67IiUZ07v4HUhOBcdabCQdSMIa
+        Gyi+fx/59b+drhBKk8zDpoJ4Og+CeeS7IvfFS67lzoo9khUbEsZfPmGcD8hP
+        WU3R6v6Q2fSYGS8xjSyNl7Ngz67RDA1tM37h2CMUY48lqkZiNbq3cNLd0vRs
+        Y/2y9qlveWET2Tv8Iy2ArcHjWTAJl0uDaTMZmf7xzOPir0yZN2zPLmJjB1Y3
+        20bNBNtXtkYiN+ORkQyj+cDFIzfBa2UdrIqnWHlMqZLwFPppdhWt0cujfX7v
+        d0jTINo0ga3egbTBU0iY7l66OnbKFSmzxu9EiAwIH8dmHhioVXbgUmKmPGy9
+        MjP+O5fuaxoTeCqYtP54ueB6E09CMwb2hAfQOyASoxcGPbiV9tDYFnu+r0im
+        oLZyPNkAyfQGywM6tx1ZA2M5WYNXyizeaF2o175PlAKtbhJJGDdDb40v+Eh2
+        Zuf5BdnlwPX3HPRG0O+ZWAt/i2V7U/D1G+BbJgU3gDtFOE3EEw789v72iVhO
+        pkESwh8613rSBmpn+iyeLJeTelfPWh26IkXmVHcjaAESCoJ19FGgrv6/0aky
+        UalkhQlyf7m1SyHS4gF4vE5XvxZJ5FenRldy9rO0YyyxxYqvzHB3ynhGp7N5
+        uoBZMpkswimhIaxW84QuSBJM8A9nxjHT9u7fMIW2wHPhKfpwpFhavWMh0Y2q
+        lQ6t+wGoE9v1SXSp4koP1KxLK3Ax6XaLDaMKvB+qHfUB23ggdE3IVnkgpZB9
+        zOEdXuOdJTh83GnA/lX9nX/4tpMY98K6jRDxA1Lb3DgUleBHX6ZltyS1w9jM
+        RIWFDA7xdVSuaSFFit7sxw1pTRCYZjisfeYGjWwmvi9QszUZPoZwb0G3KP1j
+        PfvRJ34dUXRlZ5A8C3qG6FW1dors1RV7JeGz1teRvsr9M4ifBZ4gf1WKziSA
+        dUBeQK8cWtPv6OEXQK05MTvbAjhIh9wcHx78zbOfo01tpi5YyEOb59dy489l
+        LMV5i0upXW36P66gpsCOL9AacR7HqMGneFkDuZhwNXE8i+027/UMc6hh5/OU
+        1onLuXQbakHL1M7xzqtO1uvEI113GSufHfkG+j38w94jmXrwUEP240rj6be3
+        H4J//3k7/Rrc7q8GWykpU3b2VdvGFEst6UXiwBMMtRlylL60nsiDSPYEFhTV
+        IxwO/gCy/4U3+Injgo+c05vv9M47te2u3XNXbbgzdtvxrXbmPrvm54yrfsy4
+        8qeMl2za3/Jh/eL2RV7bpbU9AB670o1f/QcAAP//AwDhnV+Y4xUAAA==
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 20:50:57 GMT
+  recorded_at: Wed, 29 Jul 2015 14:22:09 GMT
 - request:
     method: post
     uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/transactions
@@ -122,7 +121,7 @@ http_interactions:
           </options>
           <amount>2001.00</amount>
           <channel>Solidus</channel>
-          <payment-method-token>497ddg</payment-method-token>
+          <payment-method-token>gcfz7b</payment-method-token>
           <customer>
             <id nil="true"/>
             <email nil="true"/>
@@ -148,7 +147,7 @@ http_interactions:
       message: Unprocessable Entity
     headers:
       Date:
-      - Tue, 28 Jul 2015 20:50:56 GMT
+      - Wed, 29 Jul 2015 14:22:07 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -171,51 +170,51 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - d57e42c19374b43afd2269898b8ddcda
+      - 31ed9a7fc2630c0f9433557b7fca8ec8
       X-Runtime:
-      - '1.179163'
+      - '0.616404'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIADDrt1UAA7xY247bNhB9368Q/M6Vr1kn0CoNGgQJkAZBk7RoXhaUOLYY
-        S6RCUl67X9+h7pIpx08FdgFp5nA8nBsPFbw+Zal3BKW5FI+zxf185oGIJeNi
-        /zj79vUd2c5eh3cBzTkBpaQiCnQuhYbwzvOCUqTtY/vimXMOjzOqFD3P/BLl
-        d7Agp4pmzQqjqNA0NvjblQRlMrev2hM8fZwZVUBlpNTRTBbChMv5HB2dB379
-        3qjjhAoBafhFppwVOvAbQQPI6TkDYUgGJpGMGHkAEa5fPjC2D3ynsjVdaCMz
-        UI0ARZy5fLRxyChPJ3Q7rrQhgmYQ/k4VC/yeoEOltJG9lykDFfidpPHIH7sU
-        2MCHmqYQ+OVjFWN/FGS70SYFQQZa0z2EH4QudjsecwyA964QDIPX6O5cicLd
-        h/vzevszD3x8rGTaUFPoMFcyxrVSPTGIUy4At1mr7q44GhdKYemdCdeSYAVC
-        +O3LW7vNsfjul7WA+1I294bQOLZigj7qXAHYbV2qqkVSYaiJK61BrIAaYISa
-        urwZvhqewQwdWGzI/IEst1+X81cb/Nt8R6/bBbWFIme3W3iBFroFbXxG+UbH
-        l5uHly83mxddEm6rsZsqLJZZTsXZ2YlljYc/CgZPkYLDAX6LFGXmAAedpKC4
-        uI/lfXHA1i+BzbJniDQ34DSZJ1K4NTt6cuRk1ABBxFMstn0/PPlhIjDOn2kj
-        4NRei4Y2WFpYUYzhdNThYu59lEdIz96XUmHLfwBoo3gyIJhNcq34JJVJnkHj
-        kgtd66aMacrNOXwPSjApMHWNpIEo2NtOffMx8OvHNsgSOzGt+mi1mc83OA56
-        om6z2BnqXNXDN4EpY7gXrEftyZ33BoPOY4oZ6MPGa61BQtM8oUvs5A7cl0+v
-        WeGaN65FK/ciUZROhdv1fLSq0dRVMygTjNQOp5276Vud40xr1Zig3nB0G9Jg
-        TArl4RJREycTqITn+bCA3d3w/1Sxu+1HRen2oC5Hp7KqR/cA6Apxwveu2q4C
-        ehV2I271a1xdRq5BNMxcPajJjkPKdAOiRz0iUBMbLZG9UAzx4R940l0FdEaG
-        +XTbuYqpt3M8juQfsMMuhBV4jzPimZ5R9wOqjsCDULsSHrQ0gdACGZfi/9Jy
-        wURYOvjwdy0BwCE2oZ1ca7CUnbRnClvHlTFuvcTYXwJLX7xXnsvs9YWV8aPk
-        sU3nDgsFcVhxEShXKApLYdCxirFM4gw9kYoWTSjhBFneEJJIyhSomIU7mmpL
-        zVpAR4JwDyRGTtFxzgGFHnLmiKNmvlhut3bqiuGEWoeL7XZR045113JonJSk
-        8C+u7QnTvncjKOeqqpRMCpOEi6U9LEdCB/oMVGGGlvMBvJSOWT6xI6wku+XB
-        dSHte5uU/KmjW15DqMbKdqxnyKpJodIwMSbXr3yfajwh9D0yKC5sP9ZNhBQq
-        a24lT9Wt5CmVe+kfMTT3udi/BnHkSgoLeNRUsEiekPC09tvBqiCnyIM+SVve
-        1XOjS4CmJkFf7Tl/EPIZ+URP1sAYRNx0iOq1VRYK84uFuy9Sy1l7uLGmdw5Z
-        Is5p2oF7st6FTcm0h2kEbTC1LnDy4rkqDh1qIB1Pc7kjVk9FDEOO0Vd0oZOs
-        iMtLQudDJ2tgheA/C6g7ERWYEI7zX4Vrtlpv4gdYR4vFw3JF2RJ2u03EHmg0
-        X+A/8vyppY3tI4hMEs0OE33a6ltePO7T+mJGEo6FrM4DNtM7/UsMoLk2s7bB
-        8YqCqiy/8drS4ns2brwXVgP26hXfhlpjbFhGxR7w+KrudKWs53OPkGmJwxJC
-        mvPBTbiRt7fpy+23sjpszfBN6RTNKyIdK55fIYI9RG9MloSU5EgvJCPIr4gN
-        spORjLDooDITaHT/4tfs8UXsxxUXn2Vcl50woYXKluwKc5KHTd/kcCq5PB0b
-        R5Zor/2404mab/XN0XT1yw8ScHW0R+sOYPpAtD7IZ1Il3aHH+ESF0hWPZ2Dw
-        XttdyobKqfT1LgJTbgxRFx8/bl4AJxsCPAjUlDP29oLFjSTVbbSIYyfDx3RN
-        RsLGIS/sNdFVQ80XNi6QdhblY3m0VwPrKS4/VkyBxkyut+kh5etTuEnQLdZK
-        2vcraz1uqLg+2NzT/ieI1feHv+fLP1/8s/m8HHyMwBnI7UfX8G01DG0X1JI6
-        zCN7gUlw2BHselv8gAHayXF2Rl/7cHw6vtv+BwAA//8DAMPqVLX0FQAA
+        H4sIAI/huFUAA7xYS3PbNhC++1dwdIeplyPFQzPNNJNJ2iSHJukhFw9ILEXU
+        JMACoGzl13fBNylQ0akHzZC7H1aLfeEDgzcveeYdQWkuxcNidbtceCBiybg4
+        PCy+f3tP9os34U1AC05AKamIAl1IoSG88bygEmn72L145lTAw4IqRU8Lv0L5
+        PSwoqKJ5u8IoKjSNDf53LUGZLOyr9gTPHhZGlVAbqXQ0l6Uw4Xq5REeXgd+8
+        t+o4pUJAFn6VGWelDvxW0AIKespBGJKDSSUjRj6BCA9x8nMXBb5T2ZkutZE5
+        qFaAIs5cPto45JRnM7qEK22IoDmEv1PFAn8g6FEZbWUfZMZABX4vaT3ypy4F
+        NvChphkEfvVYx9ifBNlutE1BkIPW9ADhR6HLJOExxwB470vBMHit7saVKNx9
+        GLPnV/k+8PGxlmlDTanDQskY10r1yCDOuADcZqO6ueBoXCqFpXciXEuCFQjh
+        96/v7Dan4ptf1gLuS9ncG0Lj2IoJ+qgLBWC3da6qF0mFoSautAaxAmqAEWqa
+        8mb4angOC3RgdUeWO7J+/W21vV+v75evfqDX3YLGQlmw6y3s0EK/oIvPJN/o
+        +G693ew3u9d9Eq6rsasqLJZ5QcXJ2YlVjWOmeQy/PZUmTm8RjY1eiVvQM0Sa
+        G3AaKFIp3JqEvjgyMCn3IOIZltZhGIxkPRMG5990+3VqL+1dGywkrB/GcBbq
+        cLX0PskjZCfva6WwxT4CdDF7MSCYTWmj+CKVSZ9B45IzXeemjGnGzSn8AEow
+        KTBRraSFKDjYvnz7KfCbxy7IEvsuq7tmc7dc3mHzD0T9ZrEP1KnO/neBKWO4
+        F6w+7cnEe4tB5zHFDAxh07XWIKFZkdI19m0PHsrn12xwzVvXoo17kSgrp8L9
+        djlZ1WqaqhmVCUYqwdnmbvFO5zjBOjUmaDAK3YY0GJNBdZREFDtjBpXyohgX
+        sLsb/p8qdjf5pCjdHjTl6FTW9egeAH0hzvjeV9tFwKDCrsRtfo1rysg1iMaZ
+        a8YySThkTLcgetQTujSz0Qo5CMUYH37Gc+0ioDcyzqfbzkVMs53jcSL/iB12
+        JqzBB5wRz/SEun+g7gg89rQr4UFHCggtkV8p/pNWC2bC0sPH/2uPexxiM9rZ
+        tQZL2Uly5rBNXBnj1kuM/Tmw8sW791xmLy+sjR8lHp4oTLBQEIcVF4FyhaK0
+        hAUdq/nJLM7QF1KToBklvEBetPQjkjIDKhZhQjNtiVgH6CkP7oHEyCB6hjki
+        zGOGHHERbper9X5vp64YT6htuNrvVw3J2PYth8ZJRQH/5tqeMN17P4IKrupK
+        yaUwabha28NyInSgT0AVZmi9HMEr6ZTTEzvCKmpbHVxn0qG3acWWenLltfRp
+        quzGeo4cmpQqC1NjCn3v+1TjCaFvI0W5sP3YNJElUO0d5LG+gzxm8iD9I4bm
+        thCHNyCOXElhAQ+aChbJFyQ8nf1usCooKPKgL9KWd/3c6lKgmUnRV3vOPwn5
+        jHxiIGthDCJuekT92ilLhfnFwj2UmWWoA9xUMziHLO3mNOvBA9ngeqZkNsC0
+        gi6YWpc4efFcFU89aiSdTnOZEKunIoYxxxgq+tBJVsbVlaD3oZe1sFLwf0to
+        OhEVmBCO81+FW7bZ3sU72Ear1W69oWwNSXIXsR2Nliv8IaufW9raPoLIJdHs
+        aaZPO33Hi6d92lzDSMqxkNVpxGYGp3+FATTXZdY2OF5IUJUXV15SOvzAxpW3
+        wHrAXrzQ21BrjA3LqTgAHl/1Da6SDXweEDItcVhCSAs+uve28u7ufL79TtaE
+        rR2+GZ2jeWWkY8WLC0RwgBiMyYqQkgLphWQE+RWxQXYykgkWHVRmBo3un/2b
+        Pb6I/ZTi4rOM66oTZrRQ25J9Yc7ysPmbHE4ll6dT48gS7SUfdzpT852+PZou
+        fudBAq6O9mhNAOYPROuDfCZ10h16jE9UKl3zeAYG77X9pWysnEvf4CIw58YY
+        dfap4+oF8GJDgAeBmnPG3l6wuJGkuo2Wcexk+Jiu2UjYOBSlvSa6aqj9nsYF
+        0s6yeqyO9npgPcbVp4k50JTJDTY9pnxDCjcLusZaRft+ZW3ADRXXTzb3dPgJ
+        YvPj3eflnz8+f/rw1x+jjxE4A7n9xBq+q4eh7YJG0oR5Yi8wKQ47gl1vix8w
+        QImcZmfybQ/Hp+Mr7X8AAAD//wMAIW+gi+IVAAA=
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 20:50:58 GMT
+  recorded_at: Wed, 29 Jul 2015 14:22:10 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/with_a_valid_credit_card/should_have_the_correct_attributes.yml
+++ b/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/with_a_valid_credit_card/should_have_the_correct_attributes.yml
@@ -10,7 +10,7 @@ http_interactions:
         <customer>
           <first-name>Card</first-name>
           <last-name>Holder</last-name>
-          <email>brianne@jaskolski.info</email>
+          <email>madyson.gutkowski@robertscarter.com</email>
           <credit-card>
             <cardholder-name>Card Holder</cardholder-name>
             <billing-address>
@@ -44,7 +44,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 28 Jul 2015 20:50:47 GMT
+      - Wed, 29 Jul 2015 14:21:57 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -65,49 +65,49 @@ http_interactions:
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Etag:
-      - '"cff443a95121b9ebc373b9f18dccd7f6"'
+      - '"15e2aacf74149228f688c21a0de39012"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - f4a371f4612583b90d7ec7a349d0227e
+      - b0eac54bcff09f2b1268c1f86418c9d2
       X-Runtime:
-      - '2.046298'
+      - '0.782670'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIACfrt1UAA7RYS5PTOBC+8ytSuXvsvEiG8pidomqXA8sFWLa4ULLVmYjY
-        kpHkPPj125Jfcpxkkgx7SFXU/bXcavXjs8O3uywdbEAqJvjDcHQXDAfAE0EZ
-        f3oYfvn8p7cYvo1ehUmhtMhARq8Gg5DRaPY6WMyCyST0cWFkqEtWhGsP179i
-        Ptv/+nmv59tsu5uOQ9/VGvSSSaU9TjKI3hFJQ98RGH1K6tV7kVKQod9KjD4R
-        WU74fsBZ+jDUsoChb+WQEZZGsWSEc/jjB1Frkao1u2N8KUK/1BpcvhIcetZL
-        suvJthArpvvYRALRQD2iB3qfw8OQ4lKzDIbROBjNvGDujRefx8GbWfBm+vpb
-        6LcG1r7I6XX2rUH5fHsh3pJBSlXjEmXaSzCgqtqUSEn2Q6Pt6ksJymKWpnjV
-        HqFUglK1vLzkxby+3kpWZ4HXyQBX2mLbGz2MXQVobvSE/sQdV1qlJYBu/B4F
-        gw9iA+l+8MkqQv8A0FrCTgOnJpKV6qOQerUFhUY9neOuSEjK9D56D5JTwTEl
-        a0kLkvCEdRQ9fgj96m+ry4XSJPWwtiCazIJgFvquyD14wbXcW7FH0nxFxtGX
-        TxjnI/JzVhO0ejxmNjllxgu8RpZEi2lwYFdr+oa2Jr9wrBGKsccUVQOxHDxa
-        OGl3qUu3tn5Z+VS7vLCI7B7+iRLA0uDRNBiNFwuDaW4yNPXjmcdF/zBlTtis
-        XcTK9q22xQ3qRnaobIxEZrokIylGc83FlpvgNbIWVsZTLD2mVEF4At1rdhWN
-        0cujfXntt0hTINoUgc3enrTGU4iZbg9dLlvlkhRp7XcsRAqEDyPTDwzUKltw
-        IfGmPCy9IjX+O5seamoT2OVMWn+8THC9ikZj0wYOhEfQeyASozcOOnAr7aCx
-        LA58X5JUQWXleLICkuoVpge0bjuyGsYy8gReIdNopXWu3vg+UQq0uoslYdw0
-        vSc84Jbs7zB7/JzsM+D6ewZ6Jej3VDwJf4Npe5fzp7fAN0wKbgAPinAaix02
-        /Gb/5omYTqZAYsLXrWsdaQ21PX0ajRaLUTWyp40OXZEidbK7FjQACTnBPPqI
-        o7r+X+tUEatEstwEuTvcmqEQarEGHiXrHf2ZhX65qnUFZz8L28Zim6x4ZIaz
-        U0ZTOpnOkjlM49FoPp4QOoblchbTOYmDEf6wZ5wybfb+DV1oAzwTnqLrE8nS
-        6B0LiW6UpXRs3PdArdiOT6ILFZV6oGZcWoGLSTYbLBiV4/5Qzqi/sYx7QteE
-        bJQHUgrZxRyf4RXeGYL9x50HHG7VnfnHdzuLcTesyggRPyCxxY1NUQl+8jAN
-        ySWJbcamJypMZHD4r6NyTXMpEvTmMG5Ia4LAFMNx7TM7aGQz0WOOmo254VMI
-        dxd0a76dx/fTLvFriaIru4DkWdAzRK/MtXNkr8rYGwmftb6N9JXuX0D8LPAM
-        +Suv6EICWAXkBfTKoTXdiu6/AVSaM72zSYCjdMi94+ONv372c7SpuakrBnLf
-        5vmxXPtzHUtxTnEttatM/8cRVCfY6QFaIS7jGBX4HC+rIVcTrjqOF7Hd+lzP
-        MIcKdjlPaZy4nks3oRa0SGwfb71qZZ1KPFF117Hy2Yl3oN/DP+w+kqm1hxpy
-        GFcaTb7NvwbvRl//fffX/eFosJmSMGV7XzltTLJUkk4kjjzBUJs+R+lKq47c
-        i2RHYEFh1cLh6AeQwze83ieOK15yzk++8zPv3LS7dc7dNOEumG2np9qF8+yW
-        zxk3fcy48VPGSybtb3mxfnH5Iq9tr7VZAC7b1I1e/QcAAP//AwCFwPeP6hUA
-        AA==
+        H4sIAIXhuFUAA7RYS2/bOBC+51cYviuSHHntFoq6wRaLHNoCizZ76KWgxLHN
+        tUSqJGXH/fUdUm/LdmwnezBgznxDDYfz+KTww3OWjjYgFRP8fuzfeuMR8ERQ
+        xpf346dvfzvz8YfoJkwKpUUGMroZjUJGI/+P2TQIpkHo4sLIUJesCNcOrn/F
+        fLr79fOdnm2z7XMwCd2u1qAXTCrtcJJB9BeRNHQ7AqNPSb16FCkFGbqtxOgT
+        keWE70acpfdjLQsYu1YOGWFplBG6U4LfLgu9Flu1Zn9KEYPUKiFSg7xF69At
+        ocYoXwkOg60W5Hkg20KsmB5iEwlEA3WIHuldDvdjikvNMhhHE8+fOt7Mmbz7
+        5gfvJ/776ex76LYG1r7I6WX2rUH5fHs7zoJBSlXjEmXawRNTVW1KpCS7sdH2
+        9aUEZTFLU7x3h1AqQalaXt74dlLfdSWrU8LppUNX2mLb692PXQVorveI/siF
+        V1qlJYBu/Pa90SexgXQ3+moVobsHaC3hWQOnJpKV6ouQerUFhUYDXcddkZCU
+        6V30CJJTwTE/a0kLkrDEoooePoVu9bfV5UJpkjpYaBDdTT1vGrpdUffgBddy
+        Z8UOSfMVmURPXzHOB+SnrO7Q6uGQ2d0xM17gNbIkmgfenl2tGRraAn3iWCMU
+        Y48pqkZiMXqwcNLuUtdxbf268ql2eWUR2T3cIyWApcGjwPMn87nBNDcZmvpx
+        zOOif5kyJ2zWXcTKNrG2343qrravbIxEZlomIylGc83FlpvgNbIWVsZTLBym
+        VEF4Av1r7ioao9dH+/zab5GmQLQpApu9A2mNpxAz3R66XLbKBSnS2u9YiBQI
+        H0emHxioVbbgQuJNOVh6RWr872y6r6lN4Dln0vrjZILrVeRPTBvYEx5A74BI
+        jN7E68GttIfGstjzfUFSBZVVx5MVkFSvMD2gdbsjq2EsI0twCplGK61z9d51
+        iVKg1W0sCeOm6S3xgFuyMzPPzckuA65/ZKBXgv5IxVK4G0zb25wvPwDfMCm4
+        AdwrwmksnrHhN/s3T8R0MgUSE75uXetJa6jt6UHkz+d+Nb+DRoeuSJF2srsW
+        NAAJOcE8+iJQV/2vdaqIVSJZboLcH27NUAi1WAOP4mASJ3HolqtaV3D2s7Bt
+        LLbJikdmODtlFNC7YJrMIIh9fza5I3QCi8U0pjMSez7+sGccM232foMutAGe
+        CUfR9ZFkafQdC4lulKV0aNwPQK3Yjk+iCxWVeqBmXFpBF5NsNlgwKsf9oZxR
+        n7GMB8KuCdkoB6QUso85PMMrfGcIDh93GrC/VX/mH97tJKa7YVVGiPgPElvc
+        2BSRYx49TMN4SWKbsemJChMZOmS4o+qa5lIk6M1+3JDWeJ4phsPaF3bQyGai
+        hxw1G3PDxxDdXdAtutHrTd4nfi1R7MrOIHkW9ALRK3PtFNmrMvZKwmetryN9
+        pftnED8LPEH+yis6kwBWAXkFverQmn5FD98AKs2J3tkkwEE61L3jw42/fvZL
+        tKm5qQsG8tDm5bFc+3MZS+mc4lJqV5n+jyOoTrDjA7RCnMcxKvApXlZDLiZc
+        dRzPYrv1uV5gDhXsfJ7SOHE5l25CLWiR2D7eetXKepV4pOre5h3obfiH3Ucy
+        tXZQQ/bjSqO77x8/e/P5x38+PQb7o8FmSsKU7X3ltDHJUkl6kTjwBENthhyl
+        L6068iCSPYEFhVULh4MfQPbf8AafOC54yTk9+U7PvFPT7to5d9WEO2O2HZ9q
+        Z86zaz5nXPUx48pPGa+ZtG/yYv3q8kVe215rswBctqkb3fwGAAD//wMATthV
+        kfcVAAA=
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 20:50:49 GMT
+  recorded_at: Wed, 29 Jul 2015 14:22:01 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/with_a_valid_credit_card/successful/succeeds.yml
+++ b/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/with_a_valid_credit_card/successful/succeeds.yml
@@ -10,7 +10,7 @@ http_interactions:
         <customer>
           <first-name>Card</first-name>
           <last-name>Holder</last-name>
-          <email>kane_spencer@morissettenienow.info</email>
+          <email>kirstin_batz@krajcik.ca</email>
           <credit-card>
             <cardholder-name>Card Holder</cardholder-name>
             <billing-address>
@@ -44,7 +44,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 28 Jul 2015 20:50:49 GMT
+      - Wed, 29 Jul 2015 14:22:00 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -65,51 +65,51 @@ http_interactions:
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Etag:
-      - '"fd9a942ac92027a8e7cb16dd0602c4c7"'
+      - '"c3d72fc23c5193ef29768f37a5b88daf"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 7ded0a617301ac38274664219259df6a
+      - bc408b7facd66b1af3cdc6d9c81162ce
       X-Runtime:
-      - '1.775046'
+      - '0.770133'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIACnrt1UAA7RYS5PaOBC+51dQ3D02BgKkPM7Opmo3hySXZHarcknJdgPa
-        sSWPJDNDfn1a8ku2gQEme6AKdX/dbvXbDt4/Z+loB0JSzm7HkxtvPAIW84Sy
-        ze34/ttfznL8PnwTxIVUPAMRvhmNApqEvr9a+W9X08DFg6YhL94Sphw8/4zY
-        fP/zcaUWT9nT88wPXJur0WsqpHIYySD8QEQSuBZB81NSnz7yNAERuC1F82Oe
-        5YTtR4ymt2MlChi7hg4ZoWn4QBj8kDneA8QfGRdUSlAKGAXGn24oW/PALZFa
-        Jt9yBgNNa/I8oD1BJKkaYmMBREHiEDVS+xxuxwkeFc1gHPreZO54C8dffvO9
-        d3Pv3Wz1PXBbASNf5Mll8q1A+XwTHGdNIU1kY1JClROjc2WllAhB9mPN7fJL
-        CtIimqYYdockiQApa3oZ8MWsDnVFqzPC6WSDTW2xbXT7vqsATXSP8I/Eu+JK
-        JQBUY/fEG33iO0j3o6+GEbg9QCsJz5gWifZkxfrChdo+gUShAc8yl8ckpWof
-        fgTBEs4wPWtKCxKwwZoK7z4FbvW35eVcKpI6WGcQTueeNw9cm2RfvGBK7A3Z
-        IWm+JX54/xX9fIB+SmqKUneHxKbHxFiBYaRxuJx5PbmaMxQ09XnPsEYS9D2m
-        qBzx9ejOwEmrpS7jWvp15VNpeWURGR3ukRLA0mDhzJv4y6XGNJEMdP04+nHh
-        P1TqGzZnG7E1Paxtd6O6qfWZjRDPdMekJEVvPmDTYtp5Da2Flf7kawdbXEGw
-        33XDbDMaodd7+/zab5G6QJQuApO9A2qNTyCiqr10eWyZa1Kktd0R5ykQNg51
-        P9BQw2zBhcBIOVh6Rartt5T2ObUIPOdUGHucjDO1DSe+bgM94gH0HohA7/le
-        B26oHTSWRc/2NUklVFKWJVsgqdpiekBrtkWrYTQjG3AKkYZbpXL5znWJHnXy
-        JhKEMt30NnjBJ7K/wexxc7LPgKkfGagtT36kfMPdHabtTc4274HtqOBMA24l
-        YUnEn7HhN/qbJ2I66QKJCHtoTetQa6jp6bNwslxOqvE9a3hoiuCpld01oQEI
-        yAnm0Rcc1fX/mieLSMaC5trJ3eHWDIVA8Qdg4YpFu0eMYXmqeQWjj4VpY5FJ
-        Vrwyxdkpwlkync3jBcyiyWThT0niw3o9j5IFibwJ/rBnHBNtdP+GLrQDlnFH
-        Jg9HkqXhWxICzShL6dC4H4BashmfRBUyLPmQ6HFpCDYm3u2wYGSO+qGcUZ+x
-        jAdEW4TspANCcNHFHJ7hFd4agsPHnQb0VXVn/mFtJzG2wqqMEPEfxKa4sSlK
-        zo5epll4SWyase6JEhMZrF3YYtmiueAxWtP3G641nqeL4TD3BQ0Kt5nwLkfO
-        Tkf4GMLWgmZtHldvd73Fr10UbdoZS54BvbDolbl2atmrMvbKhc9IX7f0leaf
-        sfgZ4InlrwzRmQtg5ZBXrFfWWtOt6OEbQMU50TubBDi4DtkxPtz462e/tDY1
-        kbpgIA9lXh7LtT2XbSnWLS5d7SrR/3EE1Ql2fIBWiPN2jAp8ai+rIRcvXLUf
-        z9p263u9sDlUsPP3lMaIy3fpxtU8KWLTx1urWlqnEo9U3WVb+eLIO9Dv2T+M
-        HkHlg4Mc0vdrEk6/L/71/lxO//784Ut/NJhMiak0va+cNjpZKkrHEweeoFeb
-        4Y7SpVYdeeDJDsGAgqqFw8EPIP03vMEnjgteck5PvtMz79S0u3bOXTXhzpht
-        x6famfPsms8ZV33MuPJTxmsm7W95sX51+eJe24a1OQAe29QN3/wCAAD//wMA
-        7HNf1fYVAAA=
+        H4sIAIjhuFUAA7RYS2/bOBC+91cYvit62G6cQFE32GLRQ9vDtt0CvRSUNI4Z
+        S6RKUnacX98h9aIs27Gd7sGAOfMNNRzO45PCd095NlqDkJSzu7F/5Y1HwBKe
+        UvZwN/729R9nPn4XvQmTUiqeg4jejEYhTaO382B67b+dhC4utAx1yZIw5eD6
+        OWaz7fOvG3W9yTdP0yB0ba1GL6iQymEkh+hvItLQtQRan5Fm9YFnKYjQ7SRa
+        n/C8IGw7YjS7GytRwtg1csgJzaKV3oyynzFRz3+tBHlM6OoqIaFbqTWwWHIG
+        A/MFeRrINhBLqobYRABRkDpEjdS2gLtxiktFcxhHgefPHO/aCW6++tPbILj1
+        vB+h2xkY+7JIz7PvDKrnmxtxFhSyVLYupVQ5CUZU1psSIch2rLV9fSVBWUyz
+        DO/aIWkqQMpGXt1y8tjcby1r0sDppYAt7bDdle7Grga0V3pAf+CSa61UAkC1
+        fvve6CNfQ7YdfTGK0N0BdJbwpIClOpK16jMXarkBiUYDneUuT0hG1Tb6AIKl
+        nGFONpIOJOABCym6/xi69d9OV3CpSOZgcUE0mXneLHRtkX3wkimxNWKHZMWS
+        BNG3LxjnPfJjVhO0ut9nNjlkxkq8RppE86m3Y9dohoamKL8xrJEUY48pKkd8
+        Mbo3cNLt0tRuY/268ql3eWURmT3cAyWApcGiqecH87nGtDcZ6vpx9OOi/6jU
+        J2zXNmJpGlfX40ZNJ9tVtkY8122SkgyjuWJ8w3TwWlkHq+LJFw6VsiQsgf41
+        24rW6PXRPr32O6QuEKWLwGTvQNrgU4ip6g5dLTvlgpRZ43fMeQaEjSPdDzTU
+        KDtwKfCmHCy9MtP+W5vuahoTeCqoMP44OWdqGfmBbgM7wj3oLRCB0Qu8HtxI
+        e2gsix3fFySTUFtZniyBZGqJ6QGd25asgdGcPIBTiixaKlXIW9clUoKSV7Eg
+        lOmm94AH3JDtFWaPW5BtDkz9zEEtefoz4w/cXWPaXhXs4R2wNRWcacCdJCyN
+        +RM2/Hb/9omYTrpAYsJWnWs9aQM1PX0a+fO5X8/saatDVwTPrOxuBC1AQEEw
+        jz5z1NX/G50sY5kIWugg94dbOxRCxVfAooBt5GQTutWq0ZWM/ipNG4tNsuKR
+        Kc5OEU3TyXSWXMM09v3rYELSABaLWZxek9jz8Yc945Bpu/cf6EJrYDl3ZLo6
+        kCyt3rIQ6EZVSvvG/QDUic34JKqUUaWHVI9LI7AxyXqNBSML3B+qGfUJy3gg
+        tE3IWjogBBd9zP4ZXuOtITh83HHA7lb9mb9/t6MYe8O6jBDxCIkpbmyKkrOD
+        h2lZLklMM9Y9UWIig0WALZVtWgieoDe7cUNa43m6GPZrX9hBIZuJ7gvUrPUN
+        H0LYu6Bbj+KZbVSf+HVE0ZadQPIM6AWiV+XaMbJXZ+yFhM9YX0b6KvdPIH4G
+        eIT8VVd0IgGsA/IKemXRmn5FD98Aas2R3tkmwF46ZN/x/sbfPPsl2tTe1BkD
+        eWjz8lhu/DmPpVinOJfa1ab/4whqEuzwAK0Rp3GMGnyMlzWQswlXE8eT2G5z
+        rheYQw07nae0TpzPpdtQ87RMTB/vvOpkvUo8UHVnsHL/dnZz4B3oz/APs4+g
+        cuWghuzGNY0mP95/8ibf3//7/cOP3dFgMiWh0vS+atroZKklvUjseYKmNkOO
+        0pfWHXkQyZ7AgMK6hcPeDyC7b3iDTxxnvOQcn3zHZ96xaXfpnLtowp0w2w5P
+        tRPn2SWfMy76mHHhp4zXTNo/8mL96vJFXttda7sAXHapG735DQAA//8DANiV
+        tDPrFQAA
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 20:50:51 GMT
+  recorded_at: Wed, 29 Jul 2015 14:22:03 GMT
 - request:
     method: post
     uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/transactions
@@ -122,7 +122,7 @@ http_interactions:
           </options>
           <amount>50.00</amount>
           <channel>Solidus</channel>
-          <payment-method-token>9nbvq2</payment-method-token>
+          <payment-method-token>2nws3w</payment-method-token>
           <customer>
             <id nil="true"/>
             <email nil="true"/>
@@ -148,7 +148,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 28 Jul 2015 20:50:51 GMT
+      - Wed, 29 Jul 2015 14:22:01 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -169,58 +169,58 @@ http_interactions:
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Etag:
-      - '"88a7059ee55d32fd8b18c50c88872eef"'
+      - '"3417f170f80208355416fa477cb0195b"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - ad4b45d6b4e7bb3f2b54594615bd9971
+      - c94f1ac51ce4bf432720aa56c77d9f43
       X-Runtime:
-      - '1.822217'
+      - '0.631820'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIACvrt1UAA7RYS3PjNgy+76/w+K5IftVORtE2005nO93uJbt97CVDibDF
-        RiK1JOXY/fUFRUqWLCqbSw+ZsYCPIAiAwMfE709lMTuCVEzw+/niJprPgGeC
-        Mn64n3/5/Euwm79P3sVaEq5IphGVvJvNYkaTVU7XBx2H+NNIlCa6VgmpdS4k
-        +xdoHDqR0epzBYkiBcRh89PIslpK3OscMCUC3BKSL48/x+FYbMCkFDXXySa6
-        iaI4dF9GUYLMcsJ1QLLMCAP0R1UScCefyiwRkoLEjxlnxf1cyxrmofVIAtFA
-        A6Jnxsv7OcVPzUqYJ8tosQmibbDcfV5Gd5vobn37FX3tFjTr64q+ef1mgesv
-        C1xElBbotfmwQV4ub2+XP9yu2jCjdM+k0gEnJSQ/EYlh7gksoiDt9wdR4FHj
-        8CKxiEyUFeHn6wCgBkrCiuSZcHhSFaYB5I8l5lMp0Bo4Ay5ebhjfizi0SLvq
-        BVLFNHjsVbngPvmenEbhD/vnj1NWFFiFl1hs194oeIx3x/Xopo+uNFYNFgul
-        EpRKFtHsozhCcZ49NgpTzwOAC9gJ40JNDp34k5A6fwGFC0Y6557ISMH0OfkA
-        klPBMT+txAIkHMxFe/gYh+6nC6bAK1XYS7HaRNEmDvui9oBY6vJs0/2FY1oo
-        ngDLTM3EfvaA4WUZwVj3YcOVxlhAiionS7ySF2hfPrVihSsefEtWviW8btxJ
-        duvoak2raeqiVwoYm33Nqe/2dhrlbh+RkpwHSkxFr5P5jJg6L6AE7BYp0Vnu
-        xeSsqvql6avv/7s+fXf3qtx8O7tC86hspfmu8KXEvP5e6ugVda923oRafQ/l
-        CmTcRPrZcR012DMoqLIAclQBSClkgDGqBFfgPVqD6x19iE5+xyH0KqA1Mcya
-        38qrmOYYx+OV9Fe8LyOhgR7wpr+QM2r+AVvlOKPUOLFxJUWGu2Ec2plNGnhj
-        aRn99fd2ge3lNdDQytCVRWTm9JR2YqXGCk4eKtQcDX+YQjShpZQZTzD4Y9jo
-        rEfBMpOgPSYeV2DtpCDHEakNX8BdLEGYQGlyCiz/8KrgBGXVzv9UiAIInyd7
-        UijDfTpAyzfwFEGGY9yVuBbPwJNbnh6/LRHefFlNyniyjhbL3c70Q97vJOtk
-        sdst3JRft5cFjQYN1/qDKdPvu++2WVRM2mSWgus8WSzNwLoSjrBnIBKrYxkN
-        wI3U7etmeGBaTcMXmxEykl68zBuScmE0s5a1XCtduy3JAYJaFkmudaXuwpAY
-        dqJuUkkYNzfJXYEbbKVhRc6mmT+VgOVLnwpxEOERA3JT8cN74EcmBTeAe0U4
-        TcUJKUZn37U/CRVB3vFJmIq0v60mB1LoHL00c/YZmRFO8p7MgiikTF/09tOp
-        aomZxLI81IWhgT3UtaabDYbTMlJcoD2Z85ecpSh6iFbgwqdUjd0Rpxt/vmAG
-        0mG3FfvAaAlyweFs7yvaUAlaZw3Pvux+kVlQzdm3GtztQjEGn2F/lsmartab
-        bAvrdLHYLleELmG/36R0S9JogX9Il6eWWstH4KUIFH2euH2d3rHN4e1zL5gg
-        Z1iq8jzgEN0EbhCAhlwOzZVFfo+Ksnoj5+/wnYVXn04NYur1YwOqMAK0JPwA
-        OErs06eRdR72KI8S2OQgIRVDT8Zye87w+qCdxAXHtsuC+ClUnapMsmqSYvX0
-        XXNrCF5Q4UgXNEAWE5gwejjAFRLdktqLRZev9jEzI8Dx4GGHlKmmqr06sFZE
-        W2YTTGfqpYOdZOzb0ChyL/PqxXNNVG6nt2MDH7UciuRRFIzWCivZCSyBlUcz
-        7PYAU2PK7C1eApvSkRZjkdZSWQ5MQeMrr324DFX+BPUItH/7IWb02n8jHE7m
-        0Niopd8Nw/axXJH2+QzWWebhx5iWibObk1e1eUKN68NNmIBxpHF187MZs7a9
-        PGXNG30KNCRCvYMO+VKfC02Cvm+rYU/fs9VRLHz1P5ssk8sTfPV1+2e0+23x
-        Ndo99h7jFDKmmher5W6mvp2kCevAUqxzbFEB3l1T1BCY/yYMMzHoTMm7/wAA
-        AP//AwAXIF3+pBIAAA==
+        H4sIAInhuFUAA7RXTZPbNgy951d4fNdKsr1ZN6NVutOdNp3Z5NAk7TSXHUqE
+        bcYSqZKUP/LrC4qULFnUJj304BkLeAQBEAQek7enspgdQCom+P08vonmM+C5
+        oIxv7+efP/0arOdv01eJloQrkmtEpa9ms4TRNNvsT8tzEuJfI1Ga6FqlpNY7
+        Idk3oEnoREarzxWkihSQhM1fI8trKXGvc8CUCHBLSD9/fEzCsdiASSlqrtPb
+        6CaKktB9GUUJMt8RrgOS50YYoD+qkoA7+VRmiZAUJH7MOCvu51rWMA+tRxKI
+        BhoQPTNe3s8pfmpWwjxdRPFtEN0Fi58+xas3i8WbKP6CvnYLmvV1Rf/b+ssC
+        lxGlBXptPmySX68Xq7v49bJNM0o3TCodcFJC+guRmOaewCIK0n6/EwWGmoQX
+        iUXkoqwIP18nADVQElake2OS8eeM6G8/7yX5mrP9TU6S0Kot9AiZYho8Rqqd
+        4D75hpxGOQ/7QScZKwosvUsC8q/e0D3Guxg9uul4lcZSwQqhVIJSaRzNnsQB
+        ivPsY6MwRTwAuCydNHBqDs6JPwipd0dQuGCkc+6JnBRMn9N3IDkVHA+llViA
+        hK25XQ9PSej+umQKvEeFvQnL2yi6TcK+qA0Q61ue7Rl/5ngsFCPA2lIzsZk9
+        YHqZOb4BbLjSGAtIUe3IAu/hBdqXT61Y4ooH35KlbwmvG3fS9Sq6WtNqmrro
+        lQLmZlNz6ruynUa5K0ekJOeBEo+i1758RhRoXUAJ2CKw4vOdF7NjVdUvTV99
+        /9/16buwV+Xm29kVmkdlK813hS8l5vX3UkcvqHu180Oo5fdQrkDGTaR/Oq6N
+        BhsGBVUWQA4qACmFDDBHleAKvKE1uF7oQ3T6HifPi4DWxPDU/FZexDRhHA5X
+        0t/xvoyEBrrFm34kZ9R8BVvlOJjU+GCTSoocd8M8tIOaNHDXXZ4Wf/2N7eUl
+        0NDK0JU4MsN5SjuxUmMFpw8Vag6GNEwhmtRSyownmPwxbBTrQbDcHNAGDx5X
+        YO1kIMcZqQ1JwF0sK5hAaXIKLOnwquAEZdUO/UyIAgifpxtSKEN4OkBLMjCK
+        IMfZ7Upciz3wdMGPanlEePNlNRnj6SqKF+u16Ye830lWabxex260r9rLgkaD
+        hmD9yZTp99132ywqJu1hloLrXRovzMC6Eo6wZyASGcwiGoAbqdvXzfDAtJqG
+        JDYjZCS9eLlrmMmFxsxaqnKtdO22JFsIalmkO60r9SYMicKurW4ySRg3N8ld
+        gRtspWFFzqaZP5eA5UufC7EV4QETclPx7VvgByYFN4B7RTjNxAkpRmfftT8J
+        FUHe8UGYirT/rWYHpNA79NLM2T0XR5zkPZkFUciYvujtp1PVEk8Sy3JbF4b7
+        9VDXmm42GCLLSHGB9mTOX3KWoughWoFLn1I1dkecbnx/wQykw24rNoHREp7D
+        cLb3FW2qBK3zhlxfdr/ILKjm7J8a3O1CMSafYX+W6YouV7f5HayyOL5bLAld
+        wGZzm9E7kkUx/pAjTy21lg/ASxEoup+4fZ3esc3h7XPPlmDHsFTlecAhugnc
+        IAANuTM0VxZJPSrK6geJfofvLLz4XmoQU08em1CFGaAl4VvAUWLfO42s87BH
+        eZTAJgcpqRh6MpbbOMPrQDuJS45tlwXxU6g6U7lk1STF6um75tYQvKDCkS5o
+        gCwmMGn0cIArJLoltReLLl/tY2ZGgOPBww4pU01Ve3VgrYi2zCaYztRLBzvJ
+        2LehUeRe5qmLcU1Ubqe3YwNfshyK9KMoGK0VVrITWAIrD2bYbQCmxpTZWxwD
+        e6QjLeYiq6WyHJiCxlde+3AZqvwH1CPQ/u2HmNET/wfhcDJBY6OWfjcM28dy
+        RdrnM1jnuYcf47FMxG4ir2rzhBrXh5swAeNI4+rmbzNmbXt5zpuH+RRoSIR6
+        gQ75Up8LTYK+b6thT9+z1VEsydTenDK5PMGXXx7fR4+/Pd798e6p9xinkDPV
+        vFgtdzP17SRNWgeWEr3DFhXg3TVFDZiSjRiexKAzpa/+BQAA//8DABz/czKZ
+        EgAA
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 20:50:53 GMT
+  recorded_at: Wed, 29 Jul 2015 14:22:04 GMT
 - request:
     method: put
-    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/transactions/3hd4gt/submit_for_settlement
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/transactions/bfkx3y/submit_for_settlement
     body:
       encoding: UTF-8
       string: |
@@ -245,7 +245,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Jul 2015 20:50:52 GMT
+      - Wed, 29 Jul 2015 14:22:02 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -266,54 +266,53 @@ http_interactions:
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Etag:
-      - '"91caca85a12c410b3a3c1740a3110104"'
+      - '"9ce2927bd1669e4bfd86d5925fdc192f"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 8b2ac5431da26f2cfc74568cf4c5805d
+      - 73a632c9829bff51e79962e6c6e7b5d9
       X-Runtime:
-      - '0.380162'
+      - '0.263638'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIACzrt1UAA8xYS2/jNhC+768wfFcky3bjLBRtgxbFFt3uJbt97CWgxLHN
-        RiK1JOXE/fUditTLorIBigI9GLBmPlIzw3l8VPLuuSwWJ5CKCX67XF1FywXw
-        XFDGD7fLz59+CnbLd+mbREvCFck1otI3i0XCaLo+0s1BJyH+NRKlia5Vquqs
-        ZFoDfdgL+aBA6wJK4IhzAIPV5wpSRQpIwuavkeW1lPjmc8CUCNAASD/f/5iE
-        U7EBk1LUXKfb6CqKktA9GUUJMj8SrgOS50YYoHWqkoBv8qnMEiEpSHxYcFbc
-        LrWsYRlaiyQQdCQgemGsvF1SfNSshGUaR6ttEF0H8e5THL3dRm83N1/Q1m5B
-        s76u6KvXb2Nc3y9wEVFaoNXmwYY8jm9u4u9u1m3QUbpnUumAkxLSH4ikSTgQ
-        WERB2uf3okBXk7CXWEQuyorw82UAUAMlYUX6SDg8qAqPAeT3pZBMmXMFzoCL
-        pyvG9yIJLdKueoJMMQ2e/aqj4D75njxPwh8O/U8yVhSYk30srjfeKHg279z1
-        6OZdVxqzBpOFUglKpato8UGcoDgv7huFyecRwAXsGeNCzRk68Uch9fEJFC6Y
-        6Jx5IicF0+f0PUhOBcfzaSUWIOFgyu7uQxK6vy6YAkuqsEWx3kbRNgmHotZB
-        THV5tsf9meOxUPQA00wtxH5xh+FlOcFYD2HjlWazgBTVkcRYkj10KJ9bscYV
-        d74la98SXjfmpLtNdLGm1TR5MUgFjM2+5tRXvZ1GueojUpLzSIlHMehrvk36
-        /hVkROdHL+bIqmqYmr78/q/z01e7F+nme7NLNI/KZpqvhPsU89rb59EL6kHu
-        vAq1/hbKJci0iQxPx3XUYM+goMoCyEkFIKWQAcaoElyB17UGN3B9jE5/xSH0
-        IqDdYnxq/l1exDRunE4X0p+xXiZCAz1gpT+RM2r+ApvlOKPU9GCTSooc34Zx
-        ILU+Yo//mzTwZqc4+uPP6xW2l5dA413GpqwiM6fntDMrNWZweleh5gTUu7pB
-        NKGllBlLMPhT2MTXk2C5OaA9HjyuwNzJQE4jUhu+gG+xBGEGpclzYPmHVwXP
-        UFbt/M+EKIDwZbonhTLcpwO0fAO9CHIc4y7FtXgEnt7w7PQ1RnjzZDUZ4+km
-        WsW7nemHfNhJNulqt1u5Kb9piwU3DRqu9RtTpt93z22zqJi0h1kKro/pKjYD
-        60I4wZ6BSMyOOBqBG6l7r5vhgWk1DXtsRshE2lt5bEhKz2gWLWu5VLp2W5ID
-        BLUs0qPWlXobhsSwE3WVScK4qSRXAlfYSsOKnE0zfygB05c+FOIgwhMG5Kri
-        h3fAT0wKbgC3inCaiWekGN3+rv1JqAjyjo/CZKT9bzVHIIU+opVmzj4iM8JJ
-        PpBZEIWM6V5vH52qlniSmJaHujA0cIC61HSzwXBaRooeOpA5e8lZimKAaAUu
-        fErV2B1xuvHHHjOSjrut2AdGS5ALjmf7UNGGStA6b3h2//ZeZkE1Z19rcNWF
-        Ygw+w/4s0w1db7b5NWyy1eo6XhMaw36/zeg1yaIV/pAuzy21O5+AlyJQ9HGm
-        +jq9Y5vj6nP3meDIMFXlecQhugncIAA3cmdoShb5PSrK6hWcf4Wcv8N3O7h7
-        UtthTevrr04NYu72YwOqMAK0JPwAOErs1aeRdRYOKI8S2OQgJRVDS6Zy62c4
-        dfTf+x6/5PtrLpH/i0h0EpcmdnAUxE8m60zlklWzZHOg79p8Q3WDCsmNoAHy
-        ucAE1cOGLpBoltReLJp88R4zPQMclB6eTJlq6turA7uLaAtuhvPN3fmwp05t
-        G2+KLNTc/9GvmRru9HaA4vWeQ5Hei4LRWmFNO4Gl8vJkxv4eYG5gm3eLp8Ae
-        6USLschqqextgILG+257hRur/Ac0uEr4Xz/GTL57vBIOz8ZpHFnSb4a592C6
-        IgH2bVjnueemgMcy47vxvKrNZXKaH27WBowjoa2bvw3hsI32IW++VsyBxpRw
-        4OiYOQ5Z4Szo23s1PPJbe3VkUzL1aE6Z9B8j1l+uf492v6y+RLv7wWcJCjlT
-        zd3dsliT307ShHW0U6KP2KICrF2T1BCY7yrjkxh1pvTNPwAAAP//AwAWaIdX
-        vBMAAA==
+        H4sIAIrhuFUAA8xYS4/bNhC+51cYvmsly97sNtAqXXTRpkCaQ5O0aC4LShzb
+        jCVSJSmvnV/foUi9LGqzQFGgBwPSzEdqZjiPj07enspicQSpmOB3y9VVtFwA
+        zwVlfHe3/Pzp5+B2+TZ9lWhJuCK5RlT6arFIGE2z7eG0PichPhqJ0kTXKlV1
+        VjKtgT5uhXxUoHUBJXCdhA5gsPpcQapIAUnYPBpZXkuJXz4HTIkADYD088eH
+        JJyKDZiUouY6vY6uoigJ3ZtRlCDzPeE6IHluhAFapyoJ+CWfyiwRkoLElwVn
+        xd1SyxqWobVIAkFHAqIXxsq7JcVXzUpYpnG0ug6imyD+4dNq8yaO30SrL2hr
+        t6BZX1f05etjXN8vcBFRWqDV5sWG/PVtvLlZvV63QUfplkmlA05KSH8ikibh
+        QGARBWnf34kCXU3CXmIRuSgrws+XAUANlIQV6cFsyfhjRvS3Hw+SfM3Z4Son
+        SWjVFvoEmWIaPJtUe8F98i05TWIeDp1OMlYUmIh9APKvXtc9m3c+enTz/iqN
+        qYIZQqkEpdJVtHgvjlCcFx8bhUniEcBF6aSBU3NwTvxBSL1/AoULJjpnnshJ
+        wfQ5fQeSU8HxUFqJBUjYmVq7f5+E7tEFU2AdFbYS1tdRdJ2EQ1HrIOa3PNsz
+        /szxWCh6gLmlFmK7uMfwMnN8I9h4pdksIEW1JzHWYQ8dyudWrHHFvW/J2reE
+        14056e0muljTapq8GKQCxmZbc+or2U6jXMkRKcl5pMSjGDQz3yZ90wow4/O9
+        F7NnVTVMTV9+/9f56SvYi3TzfdklmkdlM81Xwn2Kee3t8+gZ9SB3XoRafw/l
+        EmTaRIan49posGVQUGUB5KgCkFLIAGNUCa7A61qDG7g+Rqe/4eR5FtBuMT41
+        /y7PYho3jscL6a9YLxOhge6w0p/IGTVfwWY5DiY1PdikkiLHr2EcSK33QrJv
+        pIG77vI+/vMvbC/Pgca7jE1ZRWY4z2lnVmrM4PS+Qs0RqHd1g2hCSykzlmDw
+        p7CJr0fBcnNAWzx4XIG5k4GcRqQ2JAG/YlnBDEqTU2BJh1cFJyirduhnQhRA
+        +DLdkkIZwtMBWpKBXgQ5zm6X4locgKcxf1LrJ4Q3b1aTMZ5uolV8e2v6IR92
+        kk26ur1dudG+aYsFNw0agvUHU6bfd+9ts6iYtIdZCq736So2A+tCOMGegUhk
+        MHE0AjdS9103wwPTahrK2IyQibS3ct8wk57GLFqqcql07bYkOwhqWaR7rSv1
+        JgyJwq6trjJJGDeV5ErgCltpWJGzaeaPJWD60sdC7ER4xIBcVXz3FviRScEN
+        4E4RTjNxQorR7e/an4SKIO/4IExG2mer2QMp9B6tNHP2wMUTTvKBzIIoZEz3
+        evvqVLXEk8S03NWF4X4D1KWmmw2GyDJS9NCBzNlLzlIUA0QrcOFTqsbuiNON
+        H3rMSDrutmIbGC3hOYxn+1DRhkrQOm/Idf/1XmZBNWd/1+CqC8UYfIb9WaYb
+        ut5c5zewyVarm3hNaAzb7XVGb0gWrfCHHHluqd35CLwUgaKHmerr9I5tjqvP
+        XWKCPcNUlecRh+gmcIMA3MidoSlZJPWoKKsXXhQ6fLeDuxy1Hda0vv6+1CDm
+        rjw2oAojQEvCd4CjxN53Glln4YDyKIFNDlJSMbRkKrd+hlNH/73v8XO+v+Tm
+        +L+IRCdxaWIHR0H8ZLLOVC5ZNUs2B/quzTdUN6iQ3AgaIJ8LTFA9bOgCiWZJ
+        7cWiyRffMdMzwEHp4cmUqaa+vTqwu4i24GY439ydD3vq1LbxpshCzaUf/Zqp
+        4U5vByje6TkU6UdRMForrGknsFReHs3Y3wLMDWzzbfEU2COdaDEWWS2VvQ1Q
+        0Hjfba9wY5X/gAZXCf/nx5jJnx0vhMPJOI0jS/rNMPceTFckwL4N6zz33BTw
+        WGZ8N55XtblMTvPDzdqAcSS0dfPYEA7baB/z5i+KOdCYEg4cHTPHISucBX1/
+        r4ZHfm+vjmxKpg7mlEn/Z8T6y8Nv0cMvDze/v3s/+FuCQs5Uc3e3LNbkt5M0
+        YR3tlOg9tqgAa9ckNWBItmJ8EqPOlL76BwAA//8DAAv0U4ixEwAA
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 20:50:54 GMT
+  recorded_at: Wed, 29 Jul 2015 14:22:05 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/with_a_valid_credit_card/with_completed_payment/can_be_fully_credited.yml
+++ b/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/with_a_valid_credit_card/with_completed_payment/can_be_fully_credited.yml
@@ -10,7 +10,7 @@ http_interactions:
         <customer>
           <first-name>Card</first-name>
           <last-name>Holder</last-name>
-          <email>megane.abshire@pfefferborer.info</email>
+          <email>rosamond.blick@kunze.biz</email>
           <credit-card>
             <cardholder-name>Card Holder</cardholder-name>
             <billing-address>
@@ -44,7 +44,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 28 Jul 2015 20:50:59 GMT
+      - Wed, 29 Jul 2015 14:22:12 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -65,51 +65,51 @@ http_interactions:
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Etag:
-      - '"b57b5b4c0a0d74e2e8040d7261ffce25"'
+      - '"5686166515d780091b0aa85b80f26620"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - fcdb6c1e164475b6548144d53081d5d4
+      - 313427b4feb19fece66c6793d06b47bd
       X-Runtime:
-      - '2.372235'
+      - '1.046020'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIADPrt1UAA7RYWY/bNhB+319h+F2WfMXeQKvtokURoGkQINkWzUtASWOb
-        XYlUSMpHfn2H1EVZttfHFtgFzJlvqOFwjk/yH7dp0luDkJSzh/5w4PV7wCIe
-        U7Z86D9//d2Z9x+DOz/KpeIpiOCu1/NpHIzH09l8+G7su7jQMtRFK8KUg+uf
-        IZvufv64V7NNutlORr5razV6QYVUDiMpBL8SEfuuJdD6hFSrDzyJQfhuI9H6
-        iKcZYbseo8lDX4kc+q6RQ0poEqSwJAwGJJQrKuCXbAGLBYiQCxADyhbcdwuc
-        tshWnEFnnwXZdmQbCCVVXWwkgCiIHaJ6apfBQz/GpaIp9IORN5w63swZzb+O
-        vPdT/Lv/5ruNgbHPs/gy+8ageL65GmdBIYll7VJMlRNhaGW5KRGC7Ppa29YX
-        EpSFNEnw0h0SxwKkrOTFdYdRddGlrMoHp5ULtrTBNne7H7sSUN/tEf2R2y61
-        UgkAVfs99Hof+RqSXe+LUfjuHqCxhK0CFutIlqpPXKjVBiQadXSWuzwiCVW7
-        4AMIFnOGyVlJGpCAJVZU8PTRd8ufjS7jUpHEwSqDYDz1vKnv2iL74DlTYmfE
-        DkmyFRkFz18wzgfkp6zGaPV0yGx8zIzleI00CuYTb8+u0nQNTXU+M6yRGGOP
-        KSp7fNF7MnDS7FIVcWV9W/mUu9xYRGYP90gJYGmwYOINR/O5xtQ36ev6cfTj
-        gr+o1Ces1zZiZTpY0+x6VUvbV9ZGPNX9kpIEo/nC+Ibp4NWyBlbEky8cKmVO
-        WATta7YVtdHt0T6/9hukLhCli8Bkb0da4WMIqWoOXSwb5YLkSeV3yHkChPUD
-        3Q801CgbcC7wphwsvTzR/lub7msqE9hmVBh/nJQztQqGI90G9oQH0DsgAqM3
-        8lpwI22hsSz2fF+QREJpZXmyApKoFaYHNG5bsgpGU7IEJxdJsFIqk+9dl0gJ
-        Sg5CQSjTTW+JB9yQ3QCzx83ILgWmvqegVjz+nvAld9eYtoOMLR+BrangTAMe
-        JGFxyLfY8Ov96ydiOukCCQl7aVxrSSuo6emTYDifD8vhPal16IrgiZXdlaAG
-        CMgI5tEnHNXV70on81BGgmY6yO3hVg8FX/EXYEG4mqX3eIfFqtLljP7ITRsL
-        TbLikSnOThFM4vFkGs1gEg6Hs9GYxCOkDdMwnpHQG+I/9oxjpvXeb9CF1sBS
-        7sj45Uiy1HrLQqAbRSkdGvcdUCM245OoXAaFHmI9Lo3AxkTrNRaMzHB/KGbU
-        n1jGHaFtQtbSASG4aGMOz/ASbw3B7uNOA/a3as/8w7udxNgblmWEiH8hMsWN
-        TVFydvQwNd0lkWnGuidKTGSwmLClsk0zwSP0Zj9uSGs8TxfDYe0rOyhkM8FT
-        hpq1vuFjCHsXdGskNpv1pE38GqJoy84geQb0CtErcu0U2Ssz9krCZ6yvI32F
-        +2cQPwM8Qf6KKzqTAJYBuYFeWbSmXdHdN4BSc6J31glwkA7Zd3y48VfPfo02
-        1Td1wUDu2rw+lit/LmMp1ikupXal6f84gqoEOz5AS8R5HKMEn+JlFeRiwlXF
-        8Sy2W53rFeZQws7nKbUTl3PpOtQ8ziPTxxuvGlmrEo9U3WWsfHbkHeht+IfZ
-        R1D54qCG7McVCf+32d/e9PO7P8a//bM/GkymRFSa3ldMG50spaQViQNP0NSm
-        y1Ha0rIjdyLZEhiQX7ZwOPgBZP8Nr/OJ44KXnNOT7/TMOzXtrp1zV024M2bb
-        8al25jy75nPGVR8zrvyUccukfZMX65vLF3ltc631AnDZpG5w9x8AAAD//wMA
-        f8dAqvQVAAA=
+        H4sIAJThuFUAA7RYS2/bOBC+91cYvit62K6dQlE22MWih6Yotu0C20tBieOY
+        a4lUScqJ8+t3SL0t27Gd7MGAOfMNNRzO45PC26csHW1AKib4zdi/8sYj4Img
+        jD/cjL9/+9NZjG+jd2FSKC0ykNG70ShkNJpez2ee/34SurgwMtQlK8K1g+vn
+        mM+2z7+u9fwxe3yaBqHb1Rr0kkmlHU4yiH4nkoZuR2D0KalXH0VKQYZuKzH6
+        RGQ54dsRZ+nNWMsCxq6VQ0ZYGkmhSCY4vYpTlqx/Wxf8Ga5i9hy6pd4g85Xg
+        MLBfkqeB7BFixfQQm0ggGqhD9Ehvc7gZU1xqlsE4Cjx/5nhzJ7j+5k8/BMEH
+        P/gRuq2BtS9yep59a1A+316Js2SQUtW4RJl2EgypqjYlUpLt2Gj7+lKCspil
+        KV62QyiVoFQtL6/5F60vuJLVeeD0cqArbbHtne7GrgI0d3pAf+CWK63SEkA3
+        fvve6JPYQLodfbWK0N0BtJbwpIFTE8lK9VlIvXoEhUYDXcddkZCU6W30ESSn
+        gmNS1pIWJOEBKym6+xS61d9WlwulSepgdUE0mXneLHS7ou7BC67l1oodkuYr
+        EkTfv2Kc98iPWU3Q6m6f2eSQGS/wGlkSLabejl2tGRraqvzOsUYoxh5TVI3E
+        cnRn4aTdpS7e2vp15VPt8soisnu4B0oAS4NHU88PFguDaW4yNPXjmMdFfzNl
+        Ttisu4iV7VxtkxvVrWxX2RiJzPRJRlKM5pqLR26C18haWBlPsXSYUgXhCfSv
+        uatojF4f7dNrv0WaAtGmCGz2DqQ1nkLMdHvoctkql6RIa79jIVIgfByZfmCg
+        VtmCC4k35WDpFanxv7PprqY2gaecSeuPg0NDryI/MG1gR7gHvQUiMXqB14Nb
+        aQ+NZbHj+5KkCiqrjicrIKleYXpA63ZHVsNYRh7AKWQarbTO1QfXJUqBVlex
+        JIybpveAB3wk2yvMHjcn2wy4/pmBXgn6MxUPwt1g2l7l/OEW+IZJwQ3gRhFO
+        Y/GEDb/Zv3kippMpkJjwdetaT1pDbU+fRv5i4VdDe9ro0BUp0k5214IGICEn
+        mEefBeqq/7VOFbFKJMtNkPvDrRkKoRZr4NGEz4PsfeiWq1pXcParsG0stsmK
+        R2Y4O2U0pZPpLJnDNPb9eTAhNIDlchbTOYk9H3/YMw6ZNnu/QRfaAM+Eo+j6
+        QLI0+o6FRDfKUto37gegVmzHJ9GFiko9UDMuraCLSTYbLBiV4/5Qzqh7LOOB
+        sGtCNsoBKYXsY/bP8ArfGYLDxx0H7G7Vn/n7dzuK6W5YlREi/oXEFjc2RSX4
+        wcM0NJckthmbnqgwkaHDgDuqrmkuRYLe7MYNaY3nmWLYr31hB41sJrrLUbMx
+        N3wI0d0F3VovuOLbPvFriWJXdgLJs6AXiF6Za8fIXpWxFxI+a30Z6SvdP4H4
+        WeAR8lde0YkEsArIK+hVh9b0K3r4BlBpjvTOJgH20qHuHe9v/PWzX6JNzU2d
+        MZCHNi+P5dqf81hK5xTnUrvK9H8cQXWCHR6gFeI0jlGBj/GyGnI24arjeBLb
+        rc/1AnOoYKfzlMaJ87l0E2pBi8T28darVtarxANVdx4r9w+8A70N/7D7SKbW
+        DmrIblxpNPnxx713fX//5Z+/vuyOBpspCVO295XTxiRLJelFYs8TDLUZcpS+
+        tOrIg0j2BBYUVi0c9n4A2X3DG3ziOOMl5/jkOz7zjk27S+fcRRPuhNl2eKqd
+        OM8u+Zxx0ceMCz9lvGbSvsmL9avLF3lte63NAnDZpm707j8AAAD//wMATWGd
+        B+wVAAA=
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 20:51:01 GMT
+  recorded_at: Wed, 29 Jul 2015 14:22:15 GMT
 - request:
     method: post
     uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/transactions
@@ -122,7 +122,7 @@ http_interactions:
           </options>
           <amount>50.00</amount>
           <channel>Solidus</channel>
-          <payment-method-token>bh7m92</payment-method-token>
+          <payment-method-token>3n72m6</payment-method-token>
           <customer>
             <id nil="true"/>
             <email nil="true"/>
@@ -148,7 +148,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 28 Jul 2015 20:51:01 GMT
+      - Wed, 29 Jul 2015 14:22:13 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -169,58 +169,58 @@ http_interactions:
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Etag:
-      - '"6bd293a8a1d60de354f13884c978684e"'
+      - '"16d0b7bbabb9b33775f67c848495f12f"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 6e27ee45f82ff21e3020257962afc551
+      - faa7e1ccbee5e4708956b0f6122d54f5
       X-Runtime:
-      - '1.878317'
+      - '0.624239'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIADXrt1UAA7RYTW/bOBC991cYvjOS7bjxFoq6QRfdLtDtoZ9ALwUlji02
-        EqklKSfeX79DkZIli0pz2UMAa+ZxODMczjwmef1YlYsjKM2luF2uruLlAkQu
-        GReH2+WXz2/Jbvk6fZEYRYWmuUFU+mKxSDhL85/32b5OIvxpJdpQ0+iUNqaQ
-        iv8LLIm8yGrNqYZU0xKSqP1pZXmjFO51IlxLgltC+uXTH0k0FVswrWQjTLqN
-        r+I4ifyXVVSg8oIKQ2ieWyFBf3StAHcKqewSqRgo/FgIXt4ujWpgGTmPFFAD
-        jFCzsF7eLhl+Gl7BMl3Hqy2Jb8h693kdv9quXsXxd/S1X9Cub2r2/PUrXH9e
-        4DOijUSv7YdL8mazvdmtXm66NKN0z5U2RNAK0jdUYZoHAocoaff9TpYYahKd
-        JQ6Ry6qm4nSZANRARXmZVnCgAq5opguu4Pd6D/s9qEwqUFdc7GUSOZxb8wCZ
-        5gYC1upCipB8Tx8nyY+G0ScZL0uswXMmsjyYg4DxPtiAbj5wbbBmsFQYU6B1
-        uooX7+URytPiU6uw1TwC+HQ9GhDMnqAXf5DKFA+gccFE592TOS25OaXvQAkm
-        BZ5OJ3EABQd7ze7eJ5H/6ZMp8UKV7kpstnG8TaKhqAsQC12d3GF/EXgsDCPA
-        ItMLuV/cYXp5TjHXQ9h4pTVGaFkXdI0X8gwdyudWbHDFXWjJJrRENK076e46
-        vljTadq6GJQC5mbfCBa6u71G+7tHlaKnkRKPYtDHQkY0GFNCBdgrMmryIogp
-        eF0PSzNU3/93fYZu7kW5hXb2hRZQuUoLXeFziQX9PdfRE+pB7TwLtfkVyhfI
-        tIkMT8f3U7LnUDLtAPSoCSglFcEc1VJoCIbW4gahj9Hp3ziCngR0JsanFrby
-        JKYN43i8kP6F92UitNAD3vQHekLNT3BVjhNKTw82qZXMcTfMQzexaQtvLa2/
-        vv3450tsL0+BxlbGrqxiO6XntDMrDVZwelej5mjZwxyiTS1j3HqCyZ/CJrEe
-        Jc/tAeEIU7gCaycDNc1IY9kC7uLowQzK0Efi2EdQBY9Q1d30z6QsgYpluqel
-        tsynB3RsA6MgOQ5xX+JG3oNIs+Km+m2N8PbLaTIu0ut4td7tbD8Uw05yna52
-        u5Wf8dfdZUGjpGVaX7m2/b7/7ppFzZU7zEoKU6SrtR1YF8IJ9gRUIZVZxyNw
-        K/X7+hlObKtp2WI7QibSs5dFS1HOfGbRcZZLpW+3FT0AaVSZFsbU+lUUUY1d
-        W19linJhb5K/AlfYSqOanmwz/1EBli/7UcqDjI6YkKtaHF6DOHIlhQXcaipY
-        Jh+RYvT2fftTUFPkHR+krUj322kKoKUp0Es7Z++FfMBJPpA5EIOMm7PefXpV
-        o/AksSwPTWlJ4AB1qelng2W0nJZn6EDm/aUnJcsBohP49GndYHfE6Sbuz5iR
-        dNxt5Z5YLRU5jGf7UNGlSrImb1n2efezzIEawf9pwN8uFGPyOfZnlV6zzfU2
-        v4HrbLW6WW8oWyPn3GbshmbxCv+QLM8tdZaPICpJNLufuX293rPN8e3z7xdS
-        cCxVdRpxiH4CtwhAQ/4M7ZVFdo+Kqn4m4+/xvYUnH04tYu7t4xKqMQOsouIA
-        OErcw6eV9R4OKI+W2OQgpTVHT6ZyF2d0GWgv8clx7bKkYQrVZDpXvJ6lWAN9
-        39xagkdqHOmSEWQxxKYxwAEukOiWMkEsunyxj50ZBMdDgB0yrtuqDurAWZFd
-        mc0wnbmXDnaSqW9jo8i97JsX45qp3F7vxgY+aQWU6SdZctZorGQvcARWHe2w
-        2wPMjSm7t3wg7kgnWsxF1ijtODADg6+87uEyVoUPaECgw9uPMZO3/jPh8GiD
-        xkatwm5Yto/lirQvZLDJ8wA/xmOZid1GXjf2CTWtDz9hCBdI45r2ZztmXXv5
-        kbcv9DnQmAgNAh3zpSEXmgX92lbLnn5lq6dYiut7e8p08M+I7zff4vW33Zvd
-        x2+DxziDnOv2xeq4m61vL2nTOrKUmAJbFMG7a4saiP1vwvgkRp0pffEfAAAA
-        //8DAP/I+q+iEgAA
+        H4sIAJXhuFUAA7RXS4/bOAy+91cEuTu28+hMC4+7gxaLLjBTYNHHoZdCtphE
+        G1tyJTmTzK9fypIdO5an3cMeAsTkJ4qkKPJT8u5UFrMjSMUEv5vHi2g+A54L
+        yvjubv71y5/B7fxd+irRknBFco2o9NVsljCaLin9uVknIf41EqWJrlVKar0X
+        kj0DTUInMlp9riBVpIAkbP4aWV5LiXudA6ZEgFtC+vXzhyQciw2YlKLmOt1E
+        iyhKQvdlFCXIfE+4DkieG2GA/qhKAu7kU5klQlKQ+DHjrLiba1nDPLQeSSAa
+        aED0zHh5N6f4qVkJ83QZxZsgugmWb77E67fL5dt49R197RY06+uK/rf1lwUu
+        I0oL9Np82CSv39xsovj1qk0zSrdMKh1wUkL6nkhMc09gEQVpvz+KAkNNwovE
+        InJRVoSfrxOAGigJK1IpFKaY00VWsPzwx6Hmz7DI2HMSWr3FPkGmmAaPlWov
+        uE++JadR0sN+1EnGigJr75KBn9Qbu8d4F6RHNx2w0lgrWCKUSlAqjaPZgzhC
+        cZ59bhSmigcAl6aTBk7NyTnxJyH1/gkULhjpnHsiJwXT5/QjSE4Fx1NpJRYg
+        YWeu1/1DErq/LpkCL1Jhr8JqE0WbJOyL2gCxwOXZHvJXjsdCMQIsLjUT29k9
+        ppflBHPdhw1XGmMBKao9WeJFvED78qkVK1xx71uy8i3hdeNOeruOrta0mqYu
+        eqWAudnWnPrubKdR7s4RKcl5oMSj6PUvnxEFWhdQAvaIjOh878XsWVX1S9NX
+        3/93ffpu7FW5+XZ2heZR2UrzXeFLiXn9vdTRC+pe7fwWavUrlCuQcRPpn47r
+        o8GWQUGVBZCjCkBKIQPMUSW4Am9oDa4X+hCdPuLoeRHQmhiemt/Ki5gmjOPx
+        SvoX3peR0EB3eNOfyBk1/4CtcpxManywSSVFjrthHtpJTRp4Yyl6/+3xI7af
+        F0FDK0NX4shM5yntxEqNFZzeV6g5GtYwhWhSSykznmDyx7BRrEfBcnNAWzx4
+        XIG1k4EcZ6Q2LAF3sbRgAqXJKbCsw6uCE5RVO/UzIQogfJ5uSaEM4+kALcvA
+        KIIch7crcS0OwNMVv1mWrxHefFlNxni6juLl7a3ph7zfSdZpfHsbu9m+bi8L
+        Gg0ahvWNKdPvu++2WVRM2sPE+a73abw0A+tKOMKegUikMMtoAG6kbl83wwPT
+        ahqW2IyQkfTi5b6hJhceM2u5yrXStduS7CCoZZHuta7U2zAkCru2WmSSMG5u
+        krsCC2ylYUXOppn/KAHLl/4oxE6ER0zIouK7d8CPTApuAHeKcJqJE1KMzr5r
+        fxIqgrzjkzAVaf9bzR5IoffopZmzBy6ecJL3ZBZEIWP6orefTlVLPEksy11d
+        GPLXQ11rutlgmCwjxQXakzl/yVmKoodoBS59StXYHXG68cMFM5AOu63YBkZL
+        eA7D2d5XtKkStM4bdn3Z/SKzoJqznzW424ViTD7D/izTNV2tN/kNrLM4vlmu
+        CF3CdrvJ6A3Johh/SJKnllrLR+ClCBQ9TNy+Tu/Y5vD2uXdLsGdYqvI84BDd
+        BG4QgIbcGZori6weFWX1m0y/w3cWXnwwNYipN49NqMIM0JLwHeAosQ+eRtZ5
+        2KM8SmCTg5RUDD0Zy22c4XWgncQlx7bLgvgpVJ2pXLJqkmL19F1zawheUOFI
+        FzRAFhOYNHo4wBUS3ZLai0WXr/YxMyPA8eBhh5Sppqq9OrBWRFtmE0xn6qWD
+        nWTs29Aoci/z1sW4Jiq309uxgU9ZDkX6WRSM1gor2QksgZVHM+y2AFNjyuwt
+        ngJ7pCMt5iKrpbIcmILGV177cBmq/AfUI9D+7YeY0Rv/N+FwMkFjo5Z+Nwzb
+        x3JF2uczWOe5hx/jsUzEbiKvavOEGteHmzAB40jj6uZvM2Zte/mRNy/zKdCQ
+        CPUCHfKlPheaBP3aVsOefmWro1iSqYM5ZXJ5gq++f3iMNg+Pr/9++NR7jFPI
+        mWperJa7mfp2kiatA0uJ3mOLCvDumqIGTMlWDE9i0JnSV/8CAAD//wMAaM0D
+        yZoSAAA=
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 20:51:03 GMT
+  recorded_at: Wed, 29 Jul 2015 14:22:16 GMT
 - request:
     method: put
-    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/transactions/cjkbfp/submit_for_settlement
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/transactions/2ddq54/submit_for_settlement
     body:
       encoding: UTF-8
       string: |
@@ -245,7 +245,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Jul 2015 20:51:02 GMT
+      - Wed, 29 Jul 2015 14:22:14 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -266,59 +266,58 @@ http_interactions:
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Etag:
-      - '"27395f0a5d610f42fc50957d3ff88182"'
+      - '"91e55449d1df018cce25f327623ffa46"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 3f3beea7426051fcbf17108bbb3a29f5
+      - 1e211f946164f99227db57e509db9386
       X-Runtime:
-      - '0.237940'
+      - '0.235534'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIADbrt1UAA8xYS4/bNhC+51cYvmsl2+usG2iVLlKkKZDmkCeQy4ISxxaz
-        EqmSlNfur+9QpF4WtVmgKNCDAWvmIzUznMdHxa9PZbE4glRM8Nvl6ipaLoBn
-        gjJ+uF1++fw22C1fJy9iLQlXJNOISl4sFjGjSfbjId1XcYh/jURpomuVqDot
-        mdZA7/dC3ivQuoASuI5DBzBYfa4gUaSAOGz+GllWS4lvPgdMiQANgOTLp9/i
-        cCo2YFKKmutkG11FURy6J6MoQWY54TogWWaEAVqnKgn4Jp/KLBGSgsSHBWfF
-        7VLLGpahtUgCQUcCohfGytslxUfNSlgm62i1DaKbYL37vI5ebVevoug72tot
-        aNbXFX3++jWu7xe4iCgt0GrzYEO+2WxvdquXmzboKN0zqXTASQnJGyJpHA4E
-        FlGQ9vmdKNDVOOwlFpGJsiL8fBkA1EBJWJGUcCAcrkiqcibh12oP+z3IVEiQ
-        V4zvRRxanF3zCKliGjy7VbngPvmenCbBD4fexykrCszIPhJp5o2BZ/POWY9u
-        3nGlMWcwVSiVoFSyihbvxRGK8+JTozDZPAK4cJ00cGpO0Ik/CKnzR1C4YKJz
-        5omMFEyfk3cgORUcT6eVWICEgym6u/dx6P66YAosqMKWxGYbRds4HIpaBzHR
-        5dke9heOx0LRA0wytRD7xR2Gl2UEYz2EjVeazQJSVDlZY0H20KF8bsUGV9z5
-        lmx8S3jdmJPsrqOLNa2myYtBKmBs9jWnvtrtNMrVHpGSnEdKPIpBV/Nt0nev
-        ICU6y72YnFXVMDV9+f1f56evci/Szfdml2gelc00Xwn3Kea1t8+jJ9SD3HkW
-        avMzlEuQaRMZno7rp8GeQUGVBZCjCkBKIQOMUSW4Aq9rDW7g+hid/Ikj6ElA
-        u8X41Py7PIlp3DgeL6R/YL1MhAZ6wEp/JGfU/ACb5Tih1PRg40qKDN+GcSC1
-        zoVkf5MG3uy0/vr24+8vsb08BRrvMjZlFZkpPaedWakxg5O7CjVHoN7VDaIJ
-        LaXMWILBn8Imvh4Fy8wB4QiTuAJzJwU5jUht2AK+xdKDGZQmp8CyD68KTlBW
-        7fRPhSiA8GWyJ4UyzKcDtGwDvQgyHOIuxbV4AJ6k+U35yxrhzZPVpIwn19Fq
-        vduZfsiHneQ6We12Kzfjr9tiwU2Dhml9Zcr0++65bRYVk/YwS8F1nqzWZmBd
-        CCfYMxCJVGYdjcCN1L3XzfDAtJqGOzYjZCLtrcwbitLzmUXLWS6Vrt2W5ABB
-        LYsk17pSr8KQKOza6iqVhHFTSa4ErrCVhhU5m2Z+XwKmL70vxEGERwzIVcUP
-        r4EfmRTcAG4V4TQVJ6QY3f6u/UmoCPKOD8JkpP1vNTmQQudopZmzD1w84iQf
-        yCyIQsp0r7ePTlVLPElMy0NdGBI4QF1qutlgGC0jRQ8dyJy95CxFMUC0Ahc+
-        pWrsjjjd+EOPGUnH3VbsA6MlPIPxbB8q2lAJWmcNy+7f3sssqObsrxpcdaEY
-        g8+wP8vkmm6ut9kNXKer1c16Q+gaOec2pTckjVb4Q7I8t9TufAReikDRh5nq
-        6/SObY6rz91mgpxhqsrziEN0E7hBAG7kztCULLJ7VJTVMxj/Chl/h+92cLek
-        tsOa1tdfnBrE3N3HBlRhBGhJ+AFwlNiLTyPrLBxQHiWwyUFCKoaWTOXWz3Dq
-        6L/3ff2U78+5Qv4vItFJXJrYwVEQP5msU5VJVs2SzYG+a/MN1Q0qJDeCBsjn
-        AhNUDxu6QKJZUnuxaPLFe8z0DHBQengyZaqpb68O7C6iLbgZzjd358OeOrVt
-        vCmyUHP7R79marjT2wGKl3sORfJJFIzWCmvaCSyVl0cz9vcAcwPbvFs8BvZI
-        J1qMRVpLZW8DFDTed9sr3FjlP6DBVcL/+jFm8tXjmXA4GadxZEm/Gebeg+mK
-        BNi3YZ1lnpsCHsuM78bzqjaXyWl+uFkbMI6Etm7+NoTDNtr7rPlWMQcaU8KB
-        o2PmOGSFs6Cf79XwyJ/t1ZFNydSDOWUy+Czz/eZbtP62e7P7+G3wWYJCxlRz
-        d7cs1uS3kzRhHe0U6xxbVIC1a5IaAvNdZXwSo86UvPgHAAD//wMAVdOdo7oT
-        AAA=
+        H4sIAJbhuFUAA8xYS2/bOBC+91cYvsuSX01aKOoGLRZdICmw6OPQS0CJY5tr
+        iVRJyon76zsUqZdFpQEWC+zBgDTzkZoZzuOj43dPRT47gVRM8Jv5chHNZ8Az
+        QRnf38y/fvkzuJ6/S17FWhKuSKYRlbyazWJGkxWlP7abOMRHI1Ga6EolqkoL
+        pjXQh52QDwq0zqEAruPQAQxWn0tIFMkhDutHI8sqKfHL54ApEaABkHz9/CEO
+        x2IDJoWouE620SKK4tC9GUUBMjsQrgOSZUYYoHWqlIBf8qnMEiEpSHyZcZbf
+        zLWsYB5aiyQQdCQgemasvJlTfNWsgHmyipbbILoKVm++LDdvV6u3y/V3tLVd
+        UK+vSvry9Rtc3y1wEVFaoNXmxYZ88+ZqGy1fr5ugo3THpNIBJwUk74mkcdgT
+        WEROmvePIkdX47CTWEQmipLw82UAUAMFYXkihcIQc7pIc5Yd/zhW/CcsUvYz
+        Dq3eYh8hVUyDZ5fyILhPviNPo6CHfa/jlOU5ZmIXgR/U67tn89ZJj27aYaUx
+        VzBFKJWgVLKMZnfiBPl59rlWmCweAFyYnjRwak7OiT8JqQ+PoHDBSOfMExnJ
+        mT4nH0FyKjieSiOxAAl7U2y3d3HoHl0wBRZSbkthvY2ibRz2RY2DmODybA/5
+        K8djoegBJpeaid3sFsPLMoKx7sOGK81mAcnLA1lhIXbQvnxqxRpX3PqWrH1L
+        eFWbk1xvoos1jabOi14qYGx2Fae+mm01ytUckZKcB0o8il43823Sda0gJTo7
+        eDEHVpb91PTl93+dn76KvUg335ddonlUNtN8JdylmNfeLo+eUfdy50Wo9e9Q
+        LkHGTaR/Oq6PBjsGOVUWQE4qACmFDDBGpeAKvK7VuJ7rQ3Ryj6PnWUCzxfDU
+        /Ls8i6ndOJ0upH9hvYyEBrrHSn8kZ9T8AzbLcTKp8cHGpRQZfg3jQCp9EJL9
+        JDW83il6/+3+I7afZ0HDXYamLCMznae0Eys1ZnByW6LmBNS7ukbUoaWUGUsw
+        +GPYyNeTYJk5oB0ePK7A3ElBjiNSGZaAX7G0YAKlyVNgWYdXBU9QlM3UT4XI
+        gfB5siO5MoynBTQsA70IMhzeLsW1OAJP1vxqVbxGeP1mNSnjySZarq6vTT/k
+        /U6ySZbX10s32zdNseCmQc2wvjFl+n373jSLkkl7mDjf9SFZrszAuhCOsGcg
+        EinMKhqAa6n7rpvhgWk1NWesR8hI2ll5qKlJx2NmDVe5VLp2W5A9BJXMk4PW
+        pXobhkRh11aLVBLGTSW5ElhgKw1LcjbN/KEATF/6kIu9CE8YkEXJ9++An5gU
+        3ABuFOE0FU9IMdr9XfuTUBLkHZ+EyUj7bDUHILk+oJVmzh65eMRJ3pNZEIWU
+        6U5vX52qkniSmJb7Kjfkr4e61LSzwTBZRvIO2pM5e8lZiryHaAQufEpV2B1x
+        uvFjhxlIh91W7AKjJTyD4WzvK5pQCVplNbvuvt7JLKji7EcFrrpQjMFn2J9l
+        sqHrzTa7gk26XF6t1oSuYLfbpvSKpNESf0iSp5banU/ACxEoepyovlbv2Oaw
+        +twtJjgwTFV5HnCIdgLXCMCN3BmakkVWj4qifOFNocW3O7jbUdNhTevrLkw1
+        YurOYwOqMAK0IHwPOErshaeWtRb2KI8S2OQgISVDS8Zy62c4dvTf+755zveX
+        XB3/F5FoJS5N7ODIiZ9MVqnKJCsnyWZP37b5muoGJZIbQQPkc4EJqocNXSDR
+        LKm9WDT54jtmegY4KD08mTJV17dXB3YX0RTcBOebuvNhTx3bNtwUWai59aNf
+        EzXc6u0AxUs9hzz5LHJGK4U17QSWysuTGfs7gKmBbb4tHgN7pCMtxiKtpLK3
+        AQoa77vNFW6o8h9Q7yrh//wQM/q344VweDJO48iSfjPMvQfTFQmwb8Mqyzw3
+        BTyWCd+N52VlLpPj/HCzNmAcCW1VP9aEwzbah6z+j2IKNKSEPUeHzLHPCidB
+        v9+r5pG/26slm5Kpozll0v0Zsf7+4T7a3t2//vvuU+9vCQoZU/Xd3bJYk99O
+        Uod1sFOsD9iiAqxdk9SAIdmJ4UkMOlPy6hcAAAD//wMA2XCkDLITAAA=
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 20:51:04 GMT
+  recorded_at: Wed, 29 Jul 2015 14:22:17 GMT
 - request:
     method: post
-    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/transactions/cjkbfp/refund
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/transactions/2ddq54/refund
     body:
       encoding: UTF-8
       string: |
@@ -343,7 +342,7 @@ http_interactions:
       message: Unprocessable Entity
     headers:
       Date:
-      - Tue, 28 Jul 2015 20:51:02 GMT
+      - Wed, 29 Jul 2015 14:22:15 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -366,22 +365,22 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 699ce3bd69e65642ce3eb1cf5562ef87
+      - d5f5705ee388f73389a75baf6df79468
       X-Runtime:
-      - '0.091660'
+      - '0.135443'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIADbrt1UAA6xSQU7DMBC89xVW7qlTRIFKjntA4gXwgE2yLYbEDusNbfp6
-        nCZpUlRx4razM7veGVltj1UpvpG8cTaNVsskEmhzVxi7T6O315f4KdrqhYLa
-        xEjkKCb0tbMe9UIIdW75rrwAwW2NaQRE0EZyoJjAesg5PNJ3bstHbmQnHDrh
-        KNSb1Tp5UPJcz0lgJpM1jMM+31aZKyOdgUclL+zVTIXewx71M1jrWBDuGlsI
-        ELNjRWPLoBKGhfHCI3OJxVLJcXS6V14dPMAxGfnL/5xWNRBU/o+goHKNZb1O
-        lkkSvPTo9uJO3YPeTZDPudxZJleWSHo26Ls8L8RiyIbyd7Acm0KfMrtuT18b
-        fjxUh+P9XWd/Ynt9KPKPz2xXK9n3lJx8/UvSwcqNP/gDAAD//wMAIaNywcAC
+        H4sIAJfhuFUAA6xSQW6DMBC85xUWd2IShbaRHOdQqS9oH7DANrUENlkvTcjr
+        awIEUkU99bazM7veGVntz1UpvpG8cXYXrZZJJNDmrjD2sIs+3t/il2ivFwpq
+        EyORo5jQ18561Ash1LXlu/IGBLc17iIggjaSA8UE1kPO4ZG+81g+ciM74dAJ
+        R6HertLkSclrPSeBmUzWMA77fFtlrox0Bh6VvLF3MxV6DwfUr2CtY0H42dhC
+        gJgdKxpbBpUwLIwXHplLLJZKjqPTvfLu4AGOychf/ue0qoGg8n8EBZVrLOs0
+        WSZJ8NKjx4s7dQ96N0E+53JnmVxZIunZoO/yvBGLIRvKv8BybAp9yWzaXo5b
+        fj5Vp/Nm3dmf2F4finVRHNONkn1PycnXvyQdrDz4gz8AAAD//wMAuTq0xMAC
         AAA=
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 20:51:04 GMT
+  recorded_at: Wed, 29 Jul 2015 14:22:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/with_a_valid_credit_card/with_completed_payment/can_be_voided.yml
+++ b/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/with_a_valid_credit_card/with_completed_payment/can_be_voided.yml
@@ -10,7 +10,7 @@ http_interactions:
         <customer>
           <first-name>Card</first-name>
           <last-name>Holder</last-name>
-          <email>wyatt@lebsack.co.uk</email>
+          <email>leslie_klocko@thiel.name</email>
           <credit-card>
             <cardholder-name>Card Holder</cardholder-name>
             <billing-address>
@@ -44,7 +44,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 28 Jul 2015 20:51:05 GMT
+      - Wed, 29 Jul 2015 14:22:17 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -65,50 +65,50 @@ http_interactions:
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Etag:
-      - '"a4b176ab92260a44184213f25638a5c7"'
+      - '"db1052bfc6dd2b7afe158f1ffd71f9b6"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - f87f4b01d9a0ee4188fcdbc373c96edc
+      - 6d58e4861940182d6d4d66ed94609f7e
       X-Runtime:
-      - '1.912919'
+      - '0.735899'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIADnrt1UAA7RYS2/bOBC+91cYviuS/Ii9gaJsdoFFsej20qYFeikoaWxz
-        LZEKSdlxf/0OqRdl2Y7tZA8BwplvqNE8Pzl4eMnSwQaEpJzdD/0bbzgAFvOE
-        suX98OnrX858+BB+COJCKp6BCD8MBgFNwvlsPPdvx37g4kHLUBevCFMOnn9F
-        bLr79fybmm2z7ctkFLi2VqMXVEjlMJJB+CcRSeBaAq1PSX36yNMEROC2Eq2P
-        eZYTthswmt4PlShg6Bo5ZISm4XZHlPo9hUiSeH0T85tiHbilSoPyFWfQM12Q
-        l55si1dQ1cfGAoiCxCFqoHY53A8TPCqawTAcef7U8WbOaP515N1N/Ttv8iNw
-        WwNjX+TJZfatQfl8kw1nQSFNZONSQpUTYzRldSkRguyGWtvVlxKURTRNMc8O
-        SRIBUtbyMsNiWee2ktUl4HTSb0tbbJvO/dhVgCadR/RHElxppRIAqvHb9waf
-        +AbS3eCLUQTuHqC1hBcFLNGRrFSfuVCrLUg06uksd3lMUqp24UcQLOEM67GW
-        tCABS2yi8PFT4Fb/trqcS0VSBxsLwvHU86aBa4vsFy+YEjsjdkiar8gofPqC
-        cT4gP2U1RqvHQ2bjY2aswDTSOJxPvD27WtM3NA35xLBHEow9lqgc8MXg0cBJ
-        e0vdt7X129qnuuWNTWTucI+0ALYGCyeeP5rPNabJZKD7x9GPC79Rqd+wOduI
-        lRla7Xwb1FNsX9kY8UyPSEpSjOaa8S3TwWtkLayMJ184VMqCsBi6abYVjdHb
-        o31+77dI3SBKN4Gp3p60xicQUdW+dHlslQtSpLXfEecpEDYM9TzQUKNswYXA
-        TDnYekWq/bcu3dfUJvCSU2H8cTLO1Cr0R3oM7AkPoHdABEZv5HXgRtpBY1vs
-        +b4gqYTKyvJkBSRVKywPaN22ZDWMZmQJTiHScKVULu9cl0gJSt5EglCmh94S
-        X3BLdrj1MjcnuwyY+pmBWvHkZ8qX3N1g2d7kbPkAbEMFZxpwLwlLIv6CA7+5
-        v3kilpNukIiwdetaR1pDzUyfhP587lf7etLo0BXBU6u6a0EDEJATrKPPHHXV
-        /7VOFpGMBc11kLvLrVkKgeJrYOE4nz4/Yw7LU60rGH0uzBiLTLHiK1PcnSKc
-        JOPJNJ7BJPL92WhMkhEsFtMomZHI8/EPZ8Yx0+bud5hCG2AZd2SyPlIsjd6y
-        EOhG2UqH1n0P1IrN+iSqkGGph0SvSyOwMfFmgw0jc7wfyh31D7ZxT2ibkI10
-        QAguupjDO7zCW0uw/7jTgP2rujv/8G0nMfaFVRsh4l+ITXPjUJScHX2ZhuGS
-        2AxjPRMlFjJY5NdS2aa54DF6sx83pDWep5vhsPaVGxSymfAxR81GZ/gYwr4F
-        3bodj6Jb1SV+LVG0ZWeQPAN6heiVtXaK7FUVeyXhM9bXkb7S/TOInwGeIH9l
-        is4kgFVA3kCvLFrT7ej+F0ClOTE7mwI4SIfsHB8e/PWzX6NNTaYuWMh9m9fX
-        cu3PZSzFeotLqV1l+j+uoLrAji/QCnEex6jAp3hZDbmYcNVxPIvt1u/1CnOo
-        YOfzlMaJy7l0E2qeFLGZ461XrazTiUe67jJWPj7yDfQ+/MPcI6hcO6gh+3FN
-        wvGP2Xfv+x+T8bf53/urwVRKTKWZfeW20cVSSTqROPAETW36HKUrrSZyL5Id
-        gQEF1QiHgz+A7H/h9X7iuOAj5/TmO73zTm27a/fcVRvujN12fKuduc+u+Tnj
-        qh8zrvwp4y2b9l0+rN/cvshr27Q2B8BjW7rhh/8AAAD//wMAX1Hy8OcVAAA=
+        H4sIAJnhuFUAA7RYS5PaOBC+51dQ3D1+ADtMyuPs1Ka2ckhSW5XHIZeUbDeg
+        YEseSYYhvz4t+SVjYICZPVCFur9ut/pth++e8my0ASEpZ/dj/8Ybj4AlPKVs
+        eT/+9vVfZz5+F70Jk1IqnoOI3oxGIU0jPwjmk78mfujiQdOQl6wIUw6ef8ds
+        tvv9eKdut/n2aRqErs3V6AUVUjmM5BD9Q0QauhZB8zPSnD7wLAURuh1F8xOe
+        F4TtRoxm92MlShi7hg45oVmUgcwo/FxnPFnzv9WKQnajRUO34mtkseIMBvIL
+        8jSgbSGWVA2xiQCiIHWIGqldAffjFI+K5jCOAs+fOd6tE9x99advg+Ctf/sj
+        dDsBI18W6WXynUD1fBMSZ4G3S2VrUkqVk6BLZa2UCEF2Y83t8ysK0mKaZRhs
+        h6SpACkbehXm7aoJcE1r8sDp5YBN7bBdTPd9VwPamB7hH4lyzZVKAKjWbt8b
+        feQbyHajL4YRunuAThKeFLBUe7JmfeZCrbYgUWjAs8zlCcmo2kUfQLCUM0zK
+        htKBBCyxkqKHj6Fb/+14BZeKZA5WF0STmefNQtcm2RcvmRI7Q3ZIVqxIEH37
+        gn4+QD8lNUGph0Nik2NirMQw0iSaT709uYYzFDRV+Y1hjaToe0xROeKL0YOB
+        k05LU7yN9MvKp9bywiIyOtwjJYClwaKp5wfzuca0kQx1/Tj6cdF3KvUN27ON
+        WJnO1TW5UdPK9pmtEM91n6QkQ2+uGd8y7byW1sEqf/KFQ6UsCUugH2ab0Qq9
+        3Nvn136H1AWidBGY7B1QG3wKMVXdpatjx1yQMmvsjjnPgLBxpPuBhhpmBy4F
+        RsrB0iszbb+ldJ/TiMBTQYWxx8k5Uyu8m24De8QD6B0Qgd4LvB7cUHtoLIs9
+        2xckk1BLWZasgGRqhekBndkWrYHRnCzBKUUWrZQq5FvXJVKCkjexIJTpprfE
+        C27J7gazxy3ILgemfuagVjz9mfEldzeYtjcFW74DtqGCMw24l4SlMX/Cht/q
+        b5+I6aQLJCZs3ZnWozZQ09OnkT+f+/XQnrY8NEXwzMruhtACBBQE8+gzR179
+        v+HJMpaJoIV2cn+4tUMhVHwNLFqks8dHjGF1anglo4+laWOxSVa8MsXZKaJp
+        OpnOkluYxr5/G0xIGsBiMYvTWxJ7Pv6wZxwTbXW/QhfaAMu5I9P1kWRp+ZaE
+        QDOqUjo07gegjmzGJ1GljCo+pHpcGoKNSTYbLBhZoH6oZtQnLOMB0RYhG+mA
+        EFz0MYdneI23huDwcacB+6r6M/+wtpMYW2FdRoj4BYkpbmyKkrOjl2nXXJKY
+        Zqx7osREBmsDtli2aCF4gtbs+w3XGs/TxXCY+4wGhdtM9FAgZ6MjfAxha0Gz
+        fgW/lnfT/uLXLYo27Ywlz4CeWfSqXDu17NUZe+XCZ6SvW/oq889Y/AzwxPJX
+        hejMBbB2yAvWK2ut6Vf08A2g5pzonW0CHFyH7BgfbvzNs59bm9pIXTCQhzLP
+        j+XGnsu2FOsWl652tej/OIKaBDs+QGvEeTtGDT61lzWQixeuxo9nbbvNvZ7Z
+        HGrY+XtKa8Tlu3Trap6WienjnVUdrVeJR6rudd6BXmf/MHoElWsHOWTfr2k0
+        +fH+k+d9f//pvx8f9keDyZSEStP7qmmjk6Wm9Dxx4Al6tRnuKH1q3ZEHnuwR
+        DCisWzgc/ACy/4Y3+MRxwUvO6cl3euadmnbXzrmrJtwZs+34VDtznl3zOeOq
+        jxlXfsp4yaR9lRfrF5cv7rVdWNsD4LFL3ejNHwAAAP//AwBhHNxr7BUAAA==
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 20:51:07 GMT
+  recorded_at: Wed, 29 Jul 2015 14:22:20 GMT
 - request:
     method: post
     uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/transactions
@@ -121,7 +121,7 @@ http_interactions:
           </options>
           <amount>50.00</amount>
           <channel>Solidus</channel>
-          <payment-method-token>3p5qq2</payment-method-token>
+          <payment-method-token>fd5qq2</payment-method-token>
           <customer>
             <id nil="true"/>
             <email nil="true"/>
@@ -147,7 +147,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 28 Jul 2015 20:51:07 GMT
+      - Wed, 29 Jul 2015 14:22:18 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -168,58 +168,58 @@ http_interactions:
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Etag:
-      - '"1dbb3ce89b1bd99e69a658d868d41c18"'
+      - '"5756c829914dd2e9af7fbe93315cb02a"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - eed53715a1334d2e620f3d06dcb15137
+      - 8dc30d1c11408e99dbe20ff808028903
       X-Runtime:
-      - '2.315415'
+      - '0.623172'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIADvrt1UAA7RXS4/bNhC+51cYvmsl+VE7gVbpIkWRok0QIC8gl4AWxxZr
-        iVRIymvn13coUrJkUZu99GDAmvlIzoszH5PX57KYnUAqJvj9PL6L5jPgmaCM
-        H+7nnz/9GWznr9MXiZaEK5JpRKUvZrOE0TRXl58vqyTEv0aiNNG1SkmtcyHZ
-        T6BJ6ERGqy8VpIoUkITNXyPLainxrEvAlAjwSEg/f/wjCcdiAyalqLlO19Fd
-        FCWh+zKKEmSWE64DkmVGGKA9qpKAJ/lUZomQFCR+zDgr7uda1jAPrUUSiAYa
-        ED0zVt7PKX5qVsI8XUTxOog2wWL7aRG9WsevovU3tLVb0KyvK/r89Rtcf13g
-        IqK0QKvNhw3ydrPcxr8t4zbMKN0zqXTASQnpGyIxzD2BRRSk/X4rCnQ1Ca8S
-        i8hEWRF+uQ0AaqAkrEgfL0Tr3wvYYc6Pd5m4q49JaFUW9ogqpsGzQZUL7pPv
-        yXkU77DvcLJjRYFld3VeHrxuezbv/PPopn1VGssEq4NSCUqlcTT7R5yguMw+
-        NgpTwAOAi9BZA6cmaU78XkidP4LCBSOdM09kpGD6kr4FyangmJBWYgESDuZm
-        PfyThO6vC6bAO1TYW7BcR9E6Cfui1kGsbXmx+f3MMS0UPcC6UjOxnz1geFlG
-        MNZ92HCl2SwgRZWTBd7BK7Qvn1qxxBUPviVL3xJeN+ak21V0s6bVNHXRKwWM
-        zb7m1HddO41y141ISS4DJaai17p8myjQuoASsD3siM5yLyZnVdUvTV99/9/1
-        6busN+XmO9kVmkdlK813ha8l5rX3WkdPqHu18yzU8lcoVyDjJtLPjmuhwZ5B
-        QZUFkJMKQEohA4xRJbgCr2sNruf6EJ2+w6nzJKDdYpg1/y5PYho3Tqcb6V94
-        X0ZCAz3gTX8kF9T8C7bKcSipcWKTSooMT8M4tEOaNHDbXV5+fffmA7aXp0DD
-        XYamxJEZzFPaiZUaKzh9qFBzMoRhCtGEllJmLMHgj2EjX0+CZSZBe0w8rsDa
-        2YEcR6Q2BAFPsYxgAqXJObCEw6uCM5RVO/B3QhRA+Dzdk0IZstMBWoKBXgQZ
-        zm1X4locgafLav3jxwLhzZfV7BhPV1G82G5NP+T9TrJK4+02dmN91V4W3DRo
-        yNUXpky/777bZlExaZNZCq7zNF6YgXUjHGEvQCSyl0U0ADdSd66b4YFpNQ1B
-        bEbISHq1Mm9YyZXCzFqacqt07bYkBwhqWaS51pV6FYZEYddWdztJGDc3yV0B
-        JCplWJGLaebfS8Dypd8LcRDhCQNyV/HDa+AnJgU3gHtFON2JM1KMbn/X/iRU
-        BHnHe2Eq0v63mhxIoXO00szZIxePOMl7MguisGP6qrefTlVLzCSW5aEuDO/r
-        oW413WwwJJaR4grtyZy95CJF0UO0Ahc+pWrsjjjd+PGKGUiH3VbsA6MlPIPh
-        bO8r2lAJWmcNsb6efpVZUM3Zjxrc7UIxBp9hf5bpii5X62wDq10cbxZLQhew
-        3693dEN2UYw/5MdTS+3OJ+ClCBQ9Tty+Tu/Y5vD2uSdLkDMsVXkZcIhuAjcI
-        wI1cDs2VRUKPirJ6Jsnv8N0OT76VGsTUc8cGVGEEaEn4AXCU2LdOI+ss7FEe
-        JbDJQUoqhpaM5dbP8NbRTuKCY9tlQfwUqt6pTLJqkmL19F1zawheUOFIFzRA
-        FhOYMHo4wA0SzZLai0WTb84xMyPA8eBhh5Sppqq9OrC7iLbMJpjO1EsHO8nY
-        tuGmyL3MMxf9mqjcTm/HBr5iORTpR1EwWiusZCewBFaezLDbA0yNKXO2eAxs
-        SkdajMWulspyYAoaX3ntw2Wo8ieoR6D9xw8xo+f9M+FwNk5jo5Z+Mwzbx3JF
-        2ufbsM4yDz/GtEz4bjyvavOEGteHmzAB40jj6uZvM2Zte/meNY/yKdCQCPUc
-        HfKlPheaBP16r4Y9/WqvjmJJpo4my+T6BF9+23yN/v66evch/tJ7jFPImGpe
-        rJa7mfp2kiasg50SnWOLCvDumqIGDMleDDMx6Ezpi/8AAAD//wMAdeBmH5US
-        AAA=
+        H4sIAJrhuFUAA7RX3W/bNhB/719h+F2R/JW4gaIuWDF0QBsMSDtgfQlo8Wxx
+        lkiFpJx4f/2OIvVlUWn3sAcD1t2Px7vj8e7H+MNrkc9OIBUT/G6+uIrmM+Cp
+        oIwf7ubfvv4WbOcfknexloQrkmpEJe9ms5jRJL1erZ/LOMS/RqI00ZVKSKUz
+        Idk/QOPQiYxWn0tIFMkhDuu/RpZWUuJe54ApEeCWkHx7/BiHY7EBk0JUXCeb
+        6CqK4tB9GUUBMs0I1wFJUyMM0B9VSsCdfCqzREgKEj9mnOV3cy0rmIfWIwlE
+        Aw2Inhkv7+YUPzUrYJ4so8UmiG6C5fuvi/Xtcnm72H5HX9sF9fqqpP9tfbfA
+        ZURpgV6bD5vkxXK5XV2vFk2aUbpnUumAkwKSX4nENPcEFpGT5vuTyDHUOOwk
+        FpGKoiT8fJkA1EBBWJ7koHIGT8dcpEfxi84Y5FdmeRxavcW+wE4xDR4rZSa4
+        T74nr6Okh/2o4x3Lc6y9LgMvmTd2j/E2SI9uOmClsVawRCiVoFSyiGafxQny
+        8+yxVpgqHgBcml41cGpOzokfhNTZCyhcMNI590RKcqbPySeQnAqOp9JILEDC
+        wVyv+89x6P66ZAq8SLm9CqtNFG3isC9qAsQCl2d7yN84HgvFCLC41EzsZ/eY
+        XpYSzHUfNlxpjAUkLzOyxIvYQfvyqRUrXHHvW7LyLeFV7U6yXUcXaxpNXRe9
+        UsDc7CtOfXe21Sh354iU5DxQ4lH0+pfPiAKtcygAe8SO6DTzYjJWlv3S9NX3
+        /12fvht7UW6+nV2heVS20nxXuCsxr79dHb2h7tXOT6FWP0K5Ahk3kf7puD4a
+        7LFtUWUB5KQCkFLIAHNUCq7AG1qN64U+RCdfcPS8CWhMDE/Nb+VNTB3G6XQh
+        /R3vy0hooAe86S/kjJq/wVY5TiY1Pti4lCLF3TAPzaQmNby2dP34/o/1DbaX
+        t0BDK0NXFpGZzlPaiZUaKzi5L1FzMqxhClGnllJmPMHkj2GjWE+CpeaA9njw
+        uAJrZwdynJHKsATcxdKCCZQmr4FlHV4VvEJRNlN/J0QOhM+TPcmVYTwtoGEZ
+        GEWQ4vB2Ja7FEXiyp5vn5yXC6y+r2TGerKPFcrs1/ZD3O8k6WWy3Czfb181l
+        QaNBzbD+ZMr0+/a7aRYlk/YwC8F1hgTDDKwL4Qh7BiKRwiyjAbiWun3dDA9M
+        q6lZYj1CRtLOy6ymJh2PmTVc5VLp2m1BDhBUMk8yrUt1G4ZEYddWVztJGDc3
+        yV2BK2ylYUnOppk/FYDlS59ycRDhCRNyVfLDB+AnJgU3gDtFON2JV6QYrX3X
+        /iSUBHnHgzAVaf9bTQYk1xl6aebskYsXnOQ9mQVR2DHd6e2nU1USTxLL8lDl
+        hvz1UJeadjYYJstI3kF7MucvOUuR9xCNwKVPqQq7I043fuwwA+mw24p9YLSE
+        pzCc7X1FkypBq7Rm193uncyCKs6eK3C3C8WYfIb9WSZrulpv0htY7xaLm+WK
+        0CXs95sdvSG7aIE/JMlTS63lE/BCBIoeJ25fq3dsc3j73LslyBiWqjwPOEQ7
+        gWsEoCF3hubKIqtHRVH+JNNv8a2FNx9MNWLqzWMTqjADtCD8ADhK7IOnlrUe
+        9iiPEtjkICElQ0/GchtneBloK3HJse0yJ34KVe1UKlk5SbF6+ra51QQvKHGk
+        CxogiwlMGj0c4AKJbkntxaLLF/uYmRHgePCwQ8pUXdVeHVgroimzCaYz9dLB
+        TjL2bWgUuZd562JcE5Xb6u3YwKcshzx5FDmjlcJKdgJLYOXJDLs9wNSYMnuL
+        l8Ae6UiLudhVUlkOTEHjK695uAxV/gPqEWj/9kPM6I3/k3B4NUFjo5Z+Nwzb
+        x3JF2uczWKWphx/jsUzEbiIvK/OEGteHmzAB40jjqvpvPWZte3lK65f5FGhI
+        hHqBDvlSnwtNgn5sq2ZPP7LVUizJ1NGcMume4KvvH79E1w9/rR7W33uPcQop
+        U/WL1XI3U99OUqd1YCnWGbaoAO+uKWrAlOzF8CQGnSl59y8AAAD//wMAgyQE
+        dZoSAAA=
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 20:51:09 GMT
+  recorded_at: Wed, 29 Jul 2015 14:22:22 GMT
 - request:
     method: put
-    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/transactions/hsyz9p/submit_for_settlement
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/transactions/c634qp/submit_for_settlement
     body:
       encoding: UTF-8
       string: |
@@ -244,7 +244,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Jul 2015 20:51:08 GMT
+      - Wed, 29 Jul 2015 14:22:19 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -265,58 +265,58 @@ http_interactions:
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Etag:
-      - '"79448435adbf11a36a53833cbdf77314"'
+      - '"dcac671e1d6ba7044c4c4daee48eb22f"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - f463a22fb2a5a7f51ca54b3d6a4f4645
+      - 7422f43eef36c0573ab73fa98071c4fd
       X-Runtime:
-      - '0.513823'
+      - '0.241736'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIADzrt1UAA8xY247bNhB9z1cYfudK8qXrBFqlixRFijZBgNyAvCwokbZY
-        S6RCUl47X9+hSN0sarNAUaAPBqSZQ2pmOJdDx6/PZbE4UamY4HfL6CZcLijP
-        BGH8cLf8/Ol3tFu+Tl7EWmKucKYBlbxYLGJGklxdfrys4gAejURprGuVqDot
-        mdaUPOyFfFBU64KWlOs4cACD1ZeKJgoXNA6aRyPLainhyxfElEBgAE0+f/wt
-        DqZiA8alqLlOtuFNGMaBezOKksosx1wjnGVGiMA6VUkKX/KpzBIhCZXwsuCs
-        uFtqWdNlYC2SFIMjCOuFsfJuSeBVs5Iuk1UYbVF4i1a7T6vw1TZ6FW6/ga3d
-        gmZ9XZHnr9/B+n6Bi4jSAqw2Lzbku9v1LvplHbVBB+meSaURxyVN3mBJ4mAg
-        sIgCt+9vRQGuxkEvsYhMlBXml+sAgIaWmBXJ4wVr/WtBU8iA400mbupjHFiV
-        hT2Cimnq2aDKBffJ9/g8iXcwdDhOWVFAEvbOy4PXbc/mnX8e3byvSkOaQHYQ
-        IqlSSRQu/hInWlwWHxuFSeARwEXorCkn5tCc+L2QOn+kChZMdM48keGC6Uvy
-        lkpOBIcDaSUWIOnB1Nn9X3HgHl0wBdRQYatgvQ3DbRwMRa2DkNvyYs/3M4dj
-        IeAB5JVaiP3iHsLLMgyxHsLGK81mCBdVjldQgz10KJ9bsYYV974la98SXjfm
-        JLtNeLWm1TR5MUgFiM2+5sRXrp1GuXLDUuLLSAlHMWhkvk36hoVSrLPci8lZ
-        VQ1T05ff/3V++or1Kt18X3aJ5lHZTPOVcJ9iXnv7PHpCPcidZ6HWP0O5BJk2
-        keHpuBaK9owWRFkAPilEpRQSQYwqwRX1utbgBq6P0ck7mDpPAtotxqfm3+VJ
-        TOPG6XQl/QPqZSI00ANU+iO+gOZvarMchpKaHmxcSZHB1yAOuNa5kOwHbuC2
-        u7z8+u7NB2gvT4HGu4xNiUIzmOe0Mys1ZHByX4HmRIl3dYNoQksIM5ZA8Kew
-        ia8nwTJzQHs4eFgBuZNSOY1IbQgCfMUyghmUxmdkCYdXRc+0rNqBnwpRUMyX
-        yR4XypCdDtASDPACZTC3XYprcaQ8WVfb799XAG/erCZlPNmE0Wq3M/2QDzvJ
-        Jol2u8iN9U1bLLApasjVF6ZMv+/e22ZRMWkPsxRc50m0MgPrSjjBXiiWwF5W
-        4QjcSN133QxHptU0dLEZIRNpb2XesJKewixamnKtdO22xAeKalkkudaVehUE
-        WEHXVjepxIybSnIlAESlDCp8Mc38oaSQvuShEAcRnCAgNxU/vKb8xKTgBnCn
-        MCepOAPF6PZ37U/SCgPveC9MRtpnq8kpLnQOVpo5e+TiESb5QGZBhKZM93r7
-        6lS1hJOEtDzUheF9A9S1ppsNhsQyXPTQgczZiy9SFANEK3DhU6qG7gjTjR97
-        zEg67rZij4wW84yOZ/tQ0YZKkDpriHX/9V5mQTVn32vqqgvEEHwG/VkmG7Le
-        bLNbukmj6Ha1xmRF9/ttSm5xGkbwA348t9TufKK8FEiR40z1dXrHNsfV5y4w
-        KGeQqvIy4hDdBG4QFDZyZ2hKFgg9KMrqGST/Fkh+h+92cBejtsOa1tfflRrE
-        3HXHBlRBBEiJ+YHCKLF3nUbWWTigPEpAk6MJrhhYMpVbP4Opo//e991Tvj/n
-        1vi/iEQncWliB0eB/WSyTlUmWTVLNgf6rs03VBdVQG4EQcDnkAmqhw1dIcEs
-        qb1YMPnqO2Z6IhiUHp5MmGrq26ujdhfRFtwM55u780FPndo23hRYqLnwg18z
-        Ndzp7QCF+zynRfJRFIzUCmraCSyVlycz9veUzg1s823xiOyRTrQQi7SWyt4G
-        CNVw322vcGOV/4AGVwn/58eYyR8dz4TTs3EaRpb0m2HuPZCuQIB9G9ZZ5rkp
-        wLHM+G48r2pzmZzmh5u1iHEgtHXz2BAO22gfsubviTnQmBIOHB0zxyErnAX9
-        fK+GR/5sr45sSqaO5pRx/2fE+tvt1/DPr5t3H6Ivg78lCM2Yau7ulsWa/HaS
-        JqyjnWKdQ4tCULsmqSmEZC/GJzHqTMmLfwAAAP//AwCK5Oj0rRMAAA==
+        H4sIAJvhuFUAA8xY227cNhB9z1cs9l2W9mJ7HchKjQZFCqRBAScFmheDEmdX
+        rCVSJqm1t1/foUjdVpRjoCjQhwWkmUNqZjiXw40/vJTF4ghSMcFvl6uLaLkA
+        ngnK+OF2+e3rL8Fu+SF5F2tJuCKZRlTybrGIGU2yq832qYpDfDQSpYmuVaLq
+        tGRaA33YC/mgQOsCSuA6Dh3AYPWpgkSRAuKweTSyrJYSv3wKmBIBGgDJt/uP
+        cTgVGzApRc11chldRFEcujejKEFmOeE6IFlmhAFapyoJ+CWfyiwRkoLElwVn
+        xe1SyxqWobVIAkFHAqIXxsrbJcVXzUpYJutodRlE18H65utq+369fr/afUdb
+        uwXN+rqib19/g+v7BS4iSgu02rzYkK/W693marNqg47SPZNKB5yUkPxMJI3D
+        gcAiCtK+fxIFuhqHvcQiMlFWhJ/OA4AaKAkrkgJUweDhsRDZo/hJ5wyKC7M8
+        Dq3eYp8hVUyDZ5cqF9wn35OXSdDDoddxyooCM7GPwHPu9d2zeeekRzfvsNKY
+        K5gilEpQKllFi8/iCMVpcd8oTBaPAC5MLxo4NSfnxF+E1PkzKFww0TnzREYK
+        pk/JJ5CcCo6n0kosQMLBFNvd5zh0jy6YAgupsKWwuYyiyzgciloHMcHlyR7y
+        N47HQtEDTC61EPvFHYaXZQRjPYSNV5rNAlJUOVljIfbQoXxuxQZX3PmWbHxL
+        eN2Yk+y20dmaVtPkxSAVMDb7mlNfzXYa5WqOSElOIyUexaCb+Tbpu1aQEp3l
+        XkzOqmqYmr78/q/z01exZ+nm+7JLNI/KZpqvhPsU89rb59Er6kHuvAm1+RHK
+        Jci0iQxPx/XRYI9tiyoLIEcVgJRCBhijSnAFXtca3MD1MTr5DUfPq4B2i/Gp
+        +Xd5FdO4cTyeSX/FepkIDfSAlf5MTqj5C2yW42RS04ONKyky/BrGgdQ6F5L9
+        TRp4s9PV/c3v22tsL6+BxruMTVlFZjrPaWdWaszg5K5CzRGod3WDaEJLKTOW
+        YPCnsImvR8Eyc0B7PHhcgbmTgpxGpDYsAb9iacEMSpOXwLIOrwpeoKzaqZ8K
+        UQDhy2RPCmUYTwdoWQZ6EWQ4vF2Ka/EIPNnTy6enNcKbN6tJGU+20Wq925l+
+        yIedZJusdruVm+3btlhw06BhWH8wZfp99942i4pJe5il4DpHgmEG1plwgj0B
+        kUhh1tEI3Ejdd90MD0yraThjM0Im0t7KvKEmPY9ZtFzlXOnabUkOENSySHKt
+        K/U+DInCrq0uUkkYN5XkSuACW2lYkZNp5g8lYPrSh0IcRHjEgFxU/PAB+JFJ
+        wQ3gVhFOU/GCFKPb37U/CRVB3vFFmIy0z1aTAyl0jlaaOfvIxTNO8oHMgiik
+        TPd6++pUtcSTxLQ81IUhfwPUuaabDYbJMlL00IHM2UtOUhQDRCtw4VOqxu6I
+        040/9piRdNxtxT4wWsIzGM/2oaINlaB11rDr/uu9zIJqzp5qcNWFYgw+w/4s
+        ky3dbC+za9imq9X1ekPoGvb7y5RekzRa4Q9J8txSu/MReCkCRR9nqq/TO7Y5
+        rj53iwlyhqkqTyMO0U3gBgG4kTtDU7LI6lFRVm+8KXT4bgd3O2o7rGl9/YWp
+        QczdeWxAFUaAloQfAEeJvfA0ss7CAeVRApscJKRiaMlUbv0Mp47+e99vXvP9
+        LVfH/0UkOolLEzs4CuInk3WqMsmqWbI50HdtvqG6QYXkRtAA+VxgguphQ2dI
+        NEtqLxZNPvuOmZ4BDkoPT6ZMNfXt1YHdRbQFN8P55u582FOnto03RRZqbv3o
+        10wNd3o7QPFSz6FI7kXBaK2wpp3AUnl5NGN/DzA3sM23xXNgj3SixViktVT2
+        NkBB4323vcKNVf4DGlwl/J8fYyb/drwRDi/GaRxZ0m+GufdguiIB9m1YZ5nn
+        poDHMuO78byqzWVymh9u1gaMI6Gtm8eGcNhG+5A1/1HMgcaUcODomDkOWeEs
+        6Md7NTzyR3t1ZFMy9WhOmfR/Rmy+f/wtuvry5+bL9vvgbwkKGVPN3d2yWJPf
+        TtKEdbRTrHNsUQHWrklqwJDsxfgkRp0pefcPAAAA//8DAEqrCSayEwAA
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 20:51:10 GMT
+  recorded_at: Wed, 29 Jul 2015 14:22:22 GMT
 - request:
     method: put
-    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/transactions/hsyz9p/void
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/transactions/c634qp/void
     body:
       encoding: UTF-8
       string: ''
@@ -337,7 +337,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 28 Jul 2015 20:51:09 GMT
+      - Wed, 29 Jul 2015 14:22:20 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -358,54 +358,54 @@ http_interactions:
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Etag:
-      - '"967ef30f1f032a97b7d483bb373bca53"'
+      - '"568fb9166b62c9866a57a4e5dc6ad956"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 1c793098a8e5be98f42ac2ede6620455
+      - 9f77b742cecb4dbae1e5852f6b27809c
       X-Runtime:
-      - '0.205131'
+      - '0.303966'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAD3rt1UAA9xY247bNhB9z1cYftdK8qXrBFqlQYoiRZMgQG5AXha0OLbY
-        lUiFpLzrfH2HInWzqM0CRYGiDwbMmUNyZjicOVTy8qEsFieQigl+s4yvouUC
-        eCYo48eb5edPvwe75cv0WaIl4YpkGlHps8UiYTTN1fnH8yoJ8a+RKE10rdKT
-        YBRoErqh0ehzBakiBSRh89fIslpK3OccMCUC3A7Szx9/S8Kp2IBJKWqu0210
-        FUVJ6EZGUYLMcsJ1QLLMCAO0RVUScCefykwRkoLEwYKz4mapZQ3L0FokgWig
-        AdELY+XNkuJQsxKW6SqKt0F0Hax2n1bRi238Itp+Q1u7Cc38uqJPn7/D+f0E
-        FxGlBVptBjbAu+v1Lv5lHbchRumBSaUDTkpIXxOJYR4ILKIg7fiNKNDVJOwl
-        FpGJsiL8fBkA1EBJWJHen4nWvxawx/O+u8rEVX2XhFZlYfeoYho8C1S54D75
-        gTxM4h0OHU72rCgw5Xrn5dHrtmfxzj+Pbt5XpTFNMDsolaBUGkeLt+IExXnx
-        sVGYBB4BXIQeNHBqDs2J3wup83tQOGGic+aJjBRMn9M3IDkVHA+klViAhKO5
-        Va/eJqH764Ip8A4V9hast1G0TcKhqHUQc1ue7fl+5ngsFD3AvFILcVi8wvCy
-        jGCsh7DxTLNYQIoqJyu8gz10KJ+bscYZr3xT1r4pvG7MSXeb6GJOq2nyYpAK
-        GJtDzanvunYa5a4bkZKcR0o8ikHZ8i2iQOsCSsDysCc6y72YnFXVMDV9+f1v
-        56fvsl6km29nl2gelc003xXuU8xrb59Hj6gHufMk1PpnKJcg0yIyPB1XQoMD
-        g4IqCyAnFYCUQgYYo0pwBV7XGtzA9TE6fYdd51FAu8T41PyrPIpp3DidLqR/
-        4H2ZCA30iDf9npxR8xfYLMempKYHm1RSZLgbxoHUOheS/SAN3FaX51/fvf6A
-        5eUx0HiVsSlxZBrznHZmpsYMTl9VqDkZwjCHaEJLKTOWYPCnsImvSEEyc0AH
-        PHicgbmzBzmNSG0IAu5iGcEMSpOHwBIOrwoeoKzahr8XogDCl+mBFMqQnQ7Q
-        Egz0Isiwb7sU1+IOeLqutt+/rxDejKxmz3i6ieLVbmfqIR9Wkk0a73axa+ub
-        9rLgokFDrr4wZep9N26LRcWkPcxScJ2n8co0rAvhBHsGIpG9rKIRuJG6fV0P
-        D0ypachh00Im0t7KvGElPYVZtDTlUunKbUmOENSySHOtK/UiDInCqq2u9pIw
-        bm6SuwJIVMqwImdTzG9LwPSlt4U4ivCEAbmq+PEl8BOTghvAjSKc7sUDUoxu
-        fVf+JFQEecd7YTLS/reaHEihc7TS9Nk7Lu6xkw9kFkRhz3Svt0OnqiWeJKbl
-        sS4M7xugLjVdbzAklpGihw5kzl5ylqIYIFqBC59SNVZH7G78rseMpONqKw6B
-        0RKewbi3DxVtqASts4ZY97v3MguqOfteg7tdKMbgM6zPMt3Q9WabXcNmH8fX
-        qzWhKzgctnt6TfZRjD/kx3NT7con4KUIFL2buX2d3rHN8e1zz5UgZ5iq8jzi
-        EF0HbhCAC7kzNFcWCT0qyuoJJP8aSX6H71ZwD6O2wo7fSg1i7rljA6owArQk
-        /AjYSuxbp5F1Fg4ojxJY5CAlFUNLpnLrZzh19J/7vnvMd1XvS6Yx028PQt72
-        JOx/GYnnj0Vi+lr+T/jdSdz1sA2zIH4SXe9VJlk1S7IH+q69NRQ/qJDUCRog
-        jw1MCD0s8AKJZkntxaLJF/sY1hAgQfC8DyhTTV3z6sCuItpCM8N159662Eum
-        to0XRfZtPnSgXzO1q9Nb4pATzqFIP4qC0VphLXMC+4SRJ0N3DgBzRMXsLe4D
-        e6QTLcZiX0tlX0EUNL7z26frWOU/oMETyr/9GDP5wPNEODwYp7FVS78Z5r2H
-        6YrE37dgnWWeFxIey4zvxvOqNo/oaX44jhEwjkS+bv42RMs2mNus+SwzBxpT
-        4YGjY8Y8ZMOzoJ+v1fDnn63VkWzJ1J05ZdJ/hFl/u/4a/fl18+5D/GXwOYZC
-        xlTzzcKyd5PfTtKEdbRSonMsUQHeXZPUgCE5iPFJjCpT+uxvAAAA//8DAAh/
-        OvCTFAAA
+        H4sIAJzhuFUAA9xYbW/bNhD+3l9h+Lsi+SWJWyjqghVDB7TFgLQD1i8BJZ4t
+        LhKpkJQT79fvKFJvFpUGGAYM+2DAvHt45B2Pdw8Vv38ui8URpGKC3yxXF9Fy
+        ATwTlPHDzfLb11+C3fJ98ibWknBFMo2o5M1iETOaZFeb7WMVh/jXSJQmulbJ
+        UTAKNA7d0Gj0qYJEkQLisPlrZFktJa5zCpgSAS4Hybe7D3E4FRswKUXNdXIZ
+        XURRHLqRUZQgs5xwHZAsM8IA96IqCbiST2WmCElB4mDBWXGz1LKGZWh3JIFo
+        oAHRC7PLmyXFoWYlLJN1tLoMoutg/fbravtuvX632n3HvXYTmvl1RV89fx3h
+        /H6Ci4jSAndtBjbAq/V6t7narNoQo3TPpNIBJyUkPxOJYR4ILKIg7fijKNDV
+        OOwlFpGJsiL8dB4A1EBJWJEUoAoG9w+FyB7ETzpnUFyY6XFo9Rb7BKliGjxW
+        qlxwn3xPnidBD4dexykrCsy7PgJPudd3j/HOSY9u3mGlMVcwRSiVoFSyihaf
+        xBGK0+KuUZgsHgFcmJ41cGpOzom/CKnzJ1A4YaJz2xMZKZg+JR9Bcio4nkor
+        sQAJB3O1bj/FofvrginwIhX2Kmwuo+gyDoei1kFMcHmyh/yN47FQ9ACTSy3E
+        fnGL4WUZwVgPYeOZxlhAiiona7yIPXQon5uxwRm3vikb3xReN9tJdtvobE6r
+        afJikAoYm33Nqe/Odhrl7hyRkpxGSjyKQe3yGVGgdQElYI1Iic5yLyZnVTVM
+        TV9+/9v56buxZ+nmW9klmkdlM813hfsU8+63z6MX1IPceRVq8yOUS5BpERme
+        jqujwR7LFlUWQI4qACmFDDBGleAKvK41uIHrY3TyGVvPi4DWxPjU/FZexDRu
+        HI9n0l/xvkyEBnrAm/5ETqj5E2yWY2dS04ONKykyXA3jQGqdC8n+Ig28sXR1
+        9/a37TWWl5dAYyvjrawi053ntDMzNWZwcluh5mhYwxyiCS2lzOwEgz+FTXxF
+        HpKZA9rjweMMzJ0U5DQitWEJuIqlBTMoTZ4Dyzq8KniGsmq7fipEAYQvkz0p
+        lGE8HaBlGehFkGHzdimuxQPwZE8vHx/XCG9GVpMynmyj1Xq3M/WQDyvJNlnt
+        divX27ftZUGjQcOwfmfK1Ptu3BaLikl7mKXgOkeCYRrWmXCCPQGRSGHW0Qjc
+        SN26rocHptQ0DLFpIRNpv8u8oSY9j1m0XOVc6cptSQ4Q1LJIcq0r9S4MicKq
+        rS5SSRg3N8ldgQsspWFFTqaY35eA6UvvC3EQ4REDclHxw3vgRyYFN4AbRThN
+        xTNSjM6+K38SKoK844swGWn/W00OpNA57tL02QcunrCTD2QWRCFlutfboVPV
+        Ek8S0/JQF4b8DVDnmq43GCbLSNFDBzK3X3KSohggWoELn1I1Vkfsbvyhx4yk
+        42or9oHREp7BuLcPFW2oBK2zhl33q/cyC6o5e6zB3S4UY/AZ1meZbOlme5ld
+        wzZdra7XG0LXsN9fpvSapNEKf0iS56Zay0fgpQgUfZi5fZ3esc3x7XNvliBn
+        mKryNOIQXQduEICG3BmaK4usHhVl9cqXQofvLLjXUVthxw+mBjH35rEBVRgB
+        WhJ+AGwl9sHTyLodDiiPEljkICEVw51M5dbPcOroP/f97Uu+qzotmcZMv98L
+        ed+TsP9jJJr33mwkpk/m/4TfncRdD9swC+In0XWqMsmqWZI90HftraH4QYWk
+        TtAAeWxgQuhhgWdI3JbUXixu+WwdwxoCJAie9wFlqqlrXh1YK6ItNDNcd+6t
+        i71kurexUWTf5msH+jVTuzq9JQ454RyK5E4UjNYKa5kT2CeMPBq6sweYIypm
+        bfEU2COdaDEWaS2VfQVR0PjOb5+uY5X/gAZPKP/yY8zkK88r4fBsnMZWLf3b
+        MO89TFck/j6DdZZ5Xkh4LDO+G8+r2jyip/nhOEbAOBL5uvnbEC3bYO6z5tvM
+        HGhMhQeOjhnzkA3Pgn5sq+HPP7LVkWzJ1IM5ZdJ/hNl8//A5uvryx+bL9vvg
+        cwyFjKnmm4Vl7ya/naQJ68hSrHMsUQHeXZPUgCHZi/FJjCpT8uZvAAAA//8D
+        AM329gGYFAAA
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 20:51:11 GMT
+  recorded_at: Wed, 29 Jul 2015 14:22:23 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/Solidus_Gateway_BraintreeGateway/braintree_attributes/creating_a_profile/billing_address_to_braintree/with_source_address/sends_payment_source_address.yml
+++ b/spec/cassettes/Solidus_Gateway_BraintreeGateway/braintree_attributes/creating_a_profile/billing_address_to_braintree/with_source_address/sends_payment_source_address.yml
@@ -1,0 +1,222 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <first-name>Card</first-name>
+          <last-name>Holder</last-name>
+          <email>kirstin@fisherkris.info</email>
+          <credit-card>
+            <cardholder-name>Card Holder</cardholder-name>
+            <billing-address>
+              <street-address>10 Lovely Street</street-address>
+              <extended-address>Northwest</extended-address>
+              <locality>Herndon</locality>
+              <region>AL</region>
+              <country-code-alpha2>US</country-code-alpha2>
+              <postal-code>35005</postal-code>
+            </billing-address>
+            <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+            <options>
+              <verify-card type="boolean">true</verify-card>
+            </options>
+          </credit-card>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.46.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 29 Jul 2015 15:27:32 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      X-Authentication:
+      - basic_auth
+      Strict-Transport-Security:
+      - max-age=31536000
+      - max-age=31536000; includeSubDomains
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"bea3696dede0bba3ed5e621274b3bb90"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - de69303281ded27d559ac1029ec85646
+      X-Runtime:
+      - '0.719830'
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAOTwuFUAA7RYS5PaOBC+z6+guHts8wiQ8jg7u6ndOWRzmWQPuaRkuxkU
+        bMmRZBjy69OSXzIGBpjZA1Wo++t2q9928OE5SwcbEJJydjf0b73hAFjME8qe
+        7oZfv/ztzIcfwpsgLqTiGYjwZjAIaBK+8xfv/NE7P3DxoGnIi1eEKQfPvyI2
+        3f36uVCzbbZ9nowC1+Zq9JIKqRxGMgj/IiIJXIug+SmpTw88TUAEbkvR/Jhn
+        OWG7AaPp3VCJAoauoUNGaBqutTLK/lhSuQKxFlTeUrbkgVuyNTBfcQY98SV5
+        7tG2EEmq+thYAFGQOEQN1C6Hu2GCR0UzGIYjz5863swZLb740/ej2fux/y1w
+        WwEjX+TJZfKtQPl8ExFnSSFNZGNSQpUTo0dlpZQIQXZDze3ySwrSIpqmGGuH
+        JIkAKWt6GeXFto5vRavTwOmkgE1tsW1I931XAZqQHuEfCXLFlUoAqMZu3xt8
+        4htId4NHwwjcPUArCc8KWKI9WbE+c6FWW5Ao1ONZ5vKYpFTtwgcQLOEMc7Km
+        tCABT1hI4f2nwK3+trycS0VSB4sLwvHU86aBa5PsixdMiZ0hOyTNV2QUfn1E
+        Px+gn5Iao9T9IbHxMTFWYBhpHM4n3p5czekLmqL8yrBGEvQ9pqgc8OXg3sBJ
+        q6Wu3Vr6deVTaXllERkd7pESwNJg4cTzR/O5xjSRDHT9OPpx4X9U6hs2Zxux
+        Mo2r7XGDupPtMxshnuk2SUmK3lwzvmXaeQ2thZX+5EuHSlkQFkM3zDajEXq9
+        t8+v/RapC0TpIjDZ26PW+AQiqtpLl8eWuSRFWtsdcZ4CYcNQ9wMNNcwWXAiM
+        lIOlV6TafkvpPqcWgeecCmOPk3GmVqE/0m1gj3gAvQMi0HsjrwM31A4ay2LP
+        9iVJJVRSliUrIKlaYXpAa7ZFq2E0I0/gFCINV0rl8r3rEilBydtIEMp003vC
+        C27J7hazx83JLgOmvmegVjz5nvIn7m4wbW9z9vQB2IYKzjTgThKWRPwZG36j
+        v3kippMukIiwdWtah1pDTU+fhP587lcze9Lw0BTBUyu7a0IDEJATzKPPOKrr
+        /zVPFpGMBc21k7vDrRkKgeJrYGG0mGw2WeCWp5pXMPqzMG0sMsmKV6Y4O0U4
+        ScaTaTyDSeT7s9GYJCNYLqdRMiOR5+MPe8Yx0Ub3G3ShDbCMOzJZH0mWhm9J
+        CDSjLKVD474HaslmfBJVyLDkQ6LHpSHYmHizwYKROeqHckb9i2XcI9oiZCMd
+        EIKLLubwDK/w1hDsP+40YF9Vd+Yf1nYSYyusyggRPyA2xY1NUXJ29DLNlkti
+        04x1T5SYyGAtwBbLFs0Fj9Gafb/hWuN5uhgOc1/QoHCbCe9z5Gx0hI8hbC1o
+        1o/lIsvm3cWvXRRt2hlLngG9sOiVuXZq2asy9sqFz0hft/SV5p+x+BngieWv
+        DNGZC2DlkFesV9Za063o/htAxTnRO5sEOLgO2TE+3PjrZ7+0NjWRumAg92Ve
+        Hsu1PZdtKdYtLl3tKtH/cQTVCXZ8gFaI83aMCnxqL6shFy9ctR/P2nbre72w
+        OVSw8/eUxojLd+nG1TwpYtPHW6taWqcSj1Td27wDvc3+YfQIKtcOcsi+X5Nw
+        /O3jP5738c+H+exxfzSYTImpNL2vnDY6WSpKxxMHnqBXm/6O0qVWHbnnyQ7B
+        gIKqhcPBDyD7b3i9TxwXvOScnnynZ96paXftnLtqwp0x245PtTPn2TWfM676
+        mHHlp4zXTNo3ebF+dfniXtuGtTkAHtvUDW9+AwAA//8DALwVjhTrFQAA
+    http_version: 
+  recorded_at: Wed, 29 Jul 2015 15:27:35 GMT
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <first-name>Card</first-name>
+          <last-name>Holder</last-name>
+          <email>kirstin@fisherkris.info</email>
+          <credit-card>
+            <cardholder-name>Card Holder</cardholder-name>
+            <billing-address>
+              <street-address>123 Source St</street-address>
+              <extended-address>Northwest</extended-address>
+              <locality>Herndon</locality>
+              <region>AL</region>
+              <country-code-alpha2>US</country-code-alpha2>
+              <postal-code>35005</postal-code>
+            </billing-address>
+            <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+            <options>
+              <verify-card type="boolean">true</verify-card>
+            </options>
+          </credit-card>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.46.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 29 Jul 2015 15:27:33 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      X-Authentication:
+      - basic_auth
+      Strict-Transport-Security:
+      - max-age=31536000
+      - max-age=31536000; includeSubDomains
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"375494a3626806ebbc8ef71272233bde"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - af022e3d268e563a46362957792e201d
+      X-Runtime:
+      - '0.754903'
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAOXwuFUAA7RYS2/bOBC+91cYvit62N4khaJs0MVusdgWC7RZoL0UlDi2
+        WUukSlKOnV/fIfW2bMd2ugcD5sw3o+G8pfB+k6WjNUjFBL8b+1feeAQ8EZTx
+        xd348fOfzs34PnoTJoXSIgMZvRmNQkYjfzKdBDN/Erp4MDTkJUvCtYPn55jP
+        ts8/bvX1U/a0mQah2+Ua9JxJpR1OMojeEUlDt0Mw/JTUp/cipSBDt6UYfiKy
+        nPDtiLP0bqxlAWPX0iEjLI1WRhnjv8+ZWoJcSaauGJ+L0C3ZBpgvBYeB+Jxs
+        BrQniBXTQ2wigWigDtEjvc3hbkzxqFkG4yjw/JnjXTvB7Wd/9ja4fjsJvoZu
+        K2Dli5yeLj9B+VagfL6NiDNnkFLVmESZdhL0qKqUEinJdmy4fX5JQVrM0hRj
+        7RBKJShV08so00Ud34pWp4HTS4EutcW2Id31XQVoQnqAfyDIFVdpCaAbu/1g
+        MvokCpnA6JMO3R1uKwYbDZwaN1asj0Lq5RMoFBrwOraKhKRMb6P3IDkVHBOy
+        prQgCQusoujhn9Ct/ra8XChNUgcrC6LJzPNmodsldW9dcC23luyQNF+SIHr8
+        hE7eQz8mNUGph31ik0NivMAYsiS6mXo7cjVnKGgr8pFjgVD0O+anGon56MHC
+        SaulLtxa+nW1U2k5q4KCQQVZHe6B/Me64NHU84ObG4NpIhma4nHM46L/mDI3
+        bM5dxNJ2rbbBjeo2tstshERmeiQjKXpzxcUTN85raC2s9KeYO0ypgvAE+mHu
+        Mhqh13v79MJvkaZAtCkCm70Dao2nEDPdXro8tsw5KdLa7liIFAgfR6YZGKhl
+        tuBCYqQcLL0iNfZ3lO5yahHY5Exae5xMcL3ENmLawA5xD3oLRKL3Aq8Ht9Qe
+        Gstix/Y5SRVUUh1LlkBSvcT0gNbsDq2GsYwswClkGi21ztVb1yVKgVZXsSSM
+        m6a3wAs+ke0VZo+bk20GXH/LQC8F/ZaKhXDXmLZXOV/cA18zKbgB3CnCaSw2
+        2O0b/c0TMZ1MgcSEr1rTetQaahv6NPJvbvxqYE8bHpoiRdrJ7prQACTkBPPo
+        I87p+n/NU0WsEsly4+T+ZGsmQqjFCngUrOLkGWNYnmpewdmPwrax2CYrXpnh
+        4JTRlE6ms+QaprHvXwcTQgOYz2cxvSax5+MPe8Yh0Ub3L+hCa+CZcBRdHUiW
+        ht+RkGhGWUr7Zv0A1JLt7CS6UFHJB2rGpSV0Mcl6jQWjctQP5Yz6gGU8IHZF
+        yFo5IKWQfcz+AV7hO0Nw+LjjgF1V/Zm/X9tRTFdhVUaI+A6JLW5sikrwg5dp
+        VlyS2GZseqLCRIbO9tthdUVzKRK0Ztdvke95nimG/dwXNGjcZqKHHDlrE+FD
+        iK4WNCv5rm8D3d/62i2xSzthw7OgF7a8MteObXpVxl6y7VnRyza+0vYTtj4L
+        PLL5lfE5cfurvPGK3aqz0/TLebj7V5wjjbOJ/t5dqBvg/V2/fvZLO1MTqTOm
+        8VDm5Zlc23PeitK5xbl7XSX6P86fOsEOT88KcdqCUYGPLWU15Oxtq/bjSatu
+        fa8X1oYKdvqS0hhx/iLduFrQIrFNvLWqpfUq8UDV/ZoXoNd/RGj0SKZWDnLI
+        rl9pNPn6x1/eu39/+/Dly9+7c8FmSsKU7X3lqDHJUlF6ntjzBLPXDBeUPrXq
+        yANP9ggWFFYtHPZ++th9vRt83DjjDef42Ds+8I6NuouG3EXj7YTBdniknTjM
+        LvmQcdFnjAs/YrxmzP6SV+pXvzjgRtuGtTkAHtu8jd78BAAA//8DAMtaZR7i
+        FQAA
+    http_version: 
+  recorded_at: Wed, 29 Jul 2015 15:27:36 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/Solidus_Gateway_BraintreeGateway/braintree_attributes/creating_a_profile/billing_address_to_braintree/without_a_source_address/fallsback_to_order_billing_address.yml
+++ b/spec/cassettes/Solidus_Gateway_BraintreeGateway/braintree_attributes/creating_a_profile/billing_address_to_braintree/without_a_source_address/fallsback_to_order_billing_address.yml
@@ -1,0 +1,223 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <first-name>Card</first-name>
+          <last-name>Holder</last-name>
+          <email>deshaun_ebert@krisleannon.biz</email>
+          <credit-card>
+            <cardholder-name>Card Holder</cardholder-name>
+            <billing-address>
+              <street-address>10 Lovely Street</street-address>
+              <extended-address>Northwest</extended-address>
+              <locality>Herndon</locality>
+              <region>AL</region>
+              <country-code-alpha2>US</country-code-alpha2>
+              <postal-code>35005</postal-code>
+            </billing-address>
+            <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+            <options>
+              <verify-card type="boolean">true</verify-card>
+            </options>
+          </credit-card>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.46.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 29 Jul 2015 15:27:34 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      X-Authentication:
+      - basic_auth
+      Strict-Transport-Security:
+      - max-age=31536000
+      - max-age=31536000; includeSubDomains
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"848cf8cef06147a676add26b355f21e3"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - d34ecbb5c8a7c46dc88c0c17f16a37c6
+      X-Runtime:
+      - '0.783503'
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAObwuFUAA7RYS5PaOBC+51dQ3D02BgJJeZyd3a3d1FY2lyR7yCUlWw3W
+        ji05kgxDfv225LcNDDDZA1Wo+2u51erHZwfvnrJ0sgOpmOD309mdN50AjwVl
+        fHs//fL5D2c9fRe+CuJCaZGBDF9NJgGjob+eLddrfxG4uDAy1MUJ4drB9Y+I
+        Lw8/vr/Rq322f1r4gdvVGvSGSaUdTjIIfyOSBm5HYPQpqVfvRUpBBm4rMfpY
+        ZDnhhwln6f1UywKmrpVDRlgaUlAJKfg3iEDqXx4lUykQzgW/i9iPwC1BBp4n
+        gsNokw15Gsn2ECmmx9hYAtFAHaIn+pDD/ZTiUrMMpqHvzZaOt3L8N59ny7f+
+        6u188TVwWwNrX+T0OvvWoHy+vRdnwyClqnGJMu3EGFdVbUqkJIep0fb1pQRl
+        EUtTvHGHUCpBqVpe3vWe1rdcyepkcHqJ0JW22PZih7GrAM3FntCfuOpKq7QE
+        0I3fM2/yQewgPUw+WUXgDgCtJTxp4NREslJ9FFIne1BoNNJ13BUxSZk+hO9B
+        cio4ZmYtaUEStlhO4cOHwK3+trpcKE1SB0sMwvnS85aB2xV1D15wLQ9W7JA0
+        T4gffvmEcT4iP2c1R6uHY2bzU2a8wGtkcbheeAO7WjM2tKX5hWONUIw9pqia
+        iM3kwcJJu0tdwbX1y8qn2uWFRWT3cE+UAJYGDxfezF+vDaa5ycDUj2MeF/7D
+        lDlhs+4iEtu+2k43qfvZUNkYicw0S0ZSjOYjF3tugtfIWlgZT7FxmFIF4TH0
+        r7mraIxeHu3La79FmgLRpghs9o6kNZ5CxHR76HLZKjekSGu/IyFMR5+Gph8Y
+        qFW24ELiTTlYekVq/O9sOtTUJvCUM2n9cTLBdRLOfNMGBsIj6AMQidHzvR7c
+        SntoLIuB7xuSKqisOp4kQFKdYHpA63ZHVsNYRrbgFDINE61z9dZ1iVKg1V0k
+        CeOm6W3xgHtyuMPscXNyyIDrbxnoRNBvqdgKd4dpe5fz7TvgOyYFN4B7RTiN
+        xBM2/Gb/5omYTqZAIsIfW9d60hpqe/oinK3Xs2pyLxoduiJF2snuWtAAJOQE
+        8+ijQF31v9apIlKxZLkJcn+4NUMh0OIRePh6m2z914Fbrmpdwdn3wraxyCYr
+        Hpnh7JThgs4Xy3gFi2g2W/lzQn3YbJYRXZHIm+EPe8Yp02bvn9CFdsAz4Sj6
+        eCJZGn3HQqIbZSkdG/cjUCu245PoQoWlHqgZl1bQxcS7HRaMynF/KGfU31jG
+        I2HXhOyUA1IK2cccn+EVvjMEx487Dxhu1Z/5x3c7i+luWJURIv6F2BY3NkUl
+        +MnDNFyXxLYZm56oMJGhQ4M7qq5pLkWM3gzjhrTG80wxHNc+s4NGNhM+5KjZ
+        mRs+hejugm5tEqrnA+LXEsWu7AKSZ0HPEL0y186RvSpjbyR81vo20le6fwHx
+        s8Az5K+8ogsJYBWQF9CrDq3pV/T4DaDSnOmdTQIcpUPdOz7e+OtnP0ebmpu6
+        YiCPbZ4fy7U/17GUzimupXaV6f84guoEOz1AK8RlHKMCn+NlNeRqwlXH8SK2
+        W5/rGeZQwS7nKY0T13PpJtSCFrHt461XraxXiSeq7jpWPj/xDvRz+IfdRzL1
+        6KCGDONKw/nX3//01l9//fzX6vVwNNhMiZmyva+cNiZZKkkvEkeeYKjNmKP0
+        pVVHHkWyJ7CgoGrhcPQDyPANb/SJ44qXnPOT7/zMOzftbp1zN024C2bb6al2
+        4Ty75XPGTR8zbvyU8ZJJ+1NerF9cvshr22ttFoDLNnXDV/8BAAD//wMA0sZM
+        P/EVAAA=
+    http_version: 
+  recorded_at: Wed, 29 Jul 2015 15:27:37 GMT
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <first-name>Card</first-name>
+          <last-name>Holder</last-name>
+          <email>deshaun_ebert@krisleannon.biz</email>
+          <credit-card>
+            <cardholder-name>Card Holder</cardholder-name>
+            <billing-address>
+              <street-address>10 Lovely Street</street-address>
+              <extended-address>Northwest</extended-address>
+              <locality>Herndon</locality>
+              <region>AL</region>
+              <country-code-alpha2>US</country-code-alpha2>
+              <postal-code>35005</postal-code>
+            </billing-address>
+            <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+            <options>
+              <verify-card type="boolean">true</verify-card>
+            </options>
+          </credit-card>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.46.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 29 Jul 2015 15:27:35 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      X-Authentication:
+      - basic_auth
+      Strict-Transport-Security:
+      - max-age=31536000
+      - max-age=31536000; includeSubDomains
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"e9f371c1ab7cb45a288630ffc4aa1edc"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - cfb07daed09e29dbee6b6825d82c7f61
+      X-Runtime:
+      - '0.725854'
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAOfwuFUAA7RYS2/jNhC+51cYviuSX7UTKErTFu0etosFNinQvQSUNI65
+        lkgtSfmRX98h9aIs27Gd9GDAnPmGGg7n8Un+/SZNeisQknJ21x9ce/0esIjH
+        lL3c9Z8e/3Rm/fvgyo9yqXgKIrjq9XwaB6Ob8fhmMhr5Li60DHXRgjDl4Po1
+        ZJPt688bNV2n68146Lu2VqPnVEjlMJJC8DsRse9aAq1PSLX6xJMYhO82Eq2P
+        eJoRtu0xmtz1lcih7xo5pIQmQQxyQXL2DCEI9etSUJkAYYyz65C++m4B0vBs
+        wRl0NpmTTUe2hlBS1cVGAoiC2CGqp7YZ3PVjXCqaQj8YeoOJ402d4c3jYHI7
+        nN6OJt99tzEw9nkWn2ffGBTPN/fizCkksaxdiqlyIoyrLDclQpBtX2vb+kKC
+        spAmCd64Q+JYgJSVvLjr+Y/qlktZlQxOKxFsaYNtLnY3diWgvtgD+gNXXWql
+        EgCq9nvg9T7zFSTb3jej8N0dQGMJGwUs1pEsVV+4UIs1SDTq6Cx3eUQSqrbB
+        JxAs5gwzs5I0IAEvWE7Bw2ffLf82uoxLRRIHSwyC0cTzJr5ri+yD50yJrRE7
+        JMkWZBg8fcM475Efsxqh1cM+s9EhM5bjNdIomI29HbtK0zU0pfnEsEZijD2m
+        qOzxee/BwEmzS1XBlfX7yqfc5Z1FZPZwD5QAlgYLxt5gOJtpTH2Tvq4fRz8u
+        +IdKfcJ6bSMWpn01na5X9bNdZW3EU90sKUkwmkvG10wHr5Y1sCKefO5QKXPC
+        Imhfs62ojd4f7dNrv0HqAlG6CEz2dqQVPoaQqubQxbJRzkmeVH6HnOuO3g90
+        P9BQo2zAucCbcrD08kT7b226q6lMYJNRYfxxUs7UIhgMdRvYEe5Bb4EIjN7Q
+        a8GNtIXGstjxfU4SCaWV5ckCSKIWmB7QuG3JKhhNyQs4uUiChVKZvHVdIiUo
+        eR0KQpluei94wDXZXmP2uBnZpsDUcwpqwePnhL9wd4Vpe52xl3tgKyo404A7
+        SVgc8g02/Hr/+omYTrpAQsKWjWstaQU1PX0cDGazQTm5x7UOXRE8sbK7EtQA
+        ARnBPPrCUVf+r3QyD2UkaKaD3B5u9VDwFV8CluxivX5NfbdYVbqc0Z+5aWOh
+        SVY8MsXZKYJxPBpPoimMw8FgOhyReAjz+SSMpyT0BvjDnnHItN77A7rQCljK
+        HRkvDyRLrbcsBLpRlNK+cd8BNWIzPonKZVDoIdbj0ghsTLRaYcHIDPeHYkb9
+        jWXcEdomZCUdEIKLNmb/DC/x1hDsPu44YHer9szfv9tRjL1hWUaI+AGRKW5s
+        ipKzg4epuS6JTDPWPVFiIoNFgy2VbZoJHqE3u3FDWuN5uhj2a9/YQSGbCR4y
+        1Kz0DR9C2LugW7+MbmZy2yZ+DVG0ZSeQPAN6g+gVuXaM7JUZeyHhM9aXkb7C
+        /ROInwEeIX/FFZ1IAMuAvINeWbSmXdHdN4BSc6R31gmwlw7Zd7y/8VfPfos2
+        1Td1xkDu2rw9lit/zmMp1inOpXal6f84gqoEOzxAS8RpHKMEH+NlFeRswlXF
+        8SS2W53rDeZQwk7nKbUT53PpOtQ8ziPTxxuvGlmrEg9U3XmsfHzgHehj+IfZ
+        R1C5dFBDduOKhP/7H395Xyez3x7//bo7GkymRFSa3ldMG50spaQViT1P0NSm
+        y1Ha0rIjdyLZEhiQX7Zw2PsBZPcNr/OJ44yXnOOT7/jMOzbtLp1zF024E2bb
+        4al24jy75HPGRR8zLvyU8Z5J+yEv1u8uX+S1zbXWC8Blk7rB1X8AAAD//wMA
+        xzAJbfEVAAA=
+    http_version: 
+  recorded_at: Wed, 29 Jul 2015 15:27:38 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
When creating a profile in Braintree, it will first look to the
payment's source's address to send as a billing address. If it doesn't
exist, will fallback to the orders's bill_address.
- Add address switch and fallback
- Specs
