### PR TITLE
Add name presence validation on create

### DIFF
--- a/app/models/concerns/add_name_validation_concern.rb
+++ b/app/models/concerns/add_name_validation_concern.rb
@@ -1,0 +1,6 @@
+module AddNameValidationConcern
+  extend ActiveSupport::Concern
+  included do
+    validates :name, presence: true, on: :create
+  end
+end

--- a/app/models/credit_card_decorator.rb
+++ b/app/models/credit_card_decorator.rb
@@ -1,1 +1,2 @@
 Spree::CreditCard.include SolidusBraintree::SkipRequireCardNumbersConcern
+Spree::CreditCard.include SolidusBraintree::AddNameValidationConcern

--- a/spec/models/spree/credit_card_spec.rb
+++ b/spec/models/spree/credit_card_spec.rb
@@ -21,5 +21,14 @@ describe Spree::CreditCard, type: :model do
     it "require_card_numbers? returns false" do
       expect(credit_card.require_card_numbers?).not_to be
     end
+
+    it "validate presence of name on create" do
+      expect do
+        credit_card = FactoryGirl.create(:credit_card,
+          payment_method: payment_method,
+          name: nil
+        )
+      end.to raise_error(ActiveRecord::RecordInvalid, /Name can't be blank/)
+    end
   end
 end


### PR DESCRIPTION
Add back name validation since that's not handled by braintree dropin or hosted fields.