### PR TITLE
supply first and last name in shipping address

### DIFF
--- a/app/models/solidus/gateway/braintree_gateway.rb
+++ b/app/models/solidus/gateway/braintree_gateway.rb
@@ -160,7 +160,14 @@ module Solidus
     end
 
     def map_address(addr)
+      full_name = addr.fetch(:name, "")
+      *first_name_parts, last_name = full_name.split(" ")
+      first_name = first_name_parts.join(" ")
+      last_name ||= ""
+
       {
+        first_name: first_name,
+        last_name: last_name,
         street_address: addr[:address1],
         extended_address: addr[:address2],
         locality: addr[:city],

--- a/lib/solidus_braintree/version.rb
+++ b/lib/solidus_braintree/version.rb
@@ -1,3 +1,3 @@
 module SolidusBraintree
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
The fields are optional for Braintree credit cards, but PayPal requires them or else the whole shipping address is stripped. The shipping address needs to arrive in PayPal to provide seller protection.

I'm not exactly happy with the way the name is split, but first and last name have already been combined at this point. Fixing it more properly requires changing solidus core's Payment::Processing module and/or Address model to keep first and last names as separate fields in active_merchant_hash. That could potentially break other payment processors' expectations.