### PR TITLE
Add AVS response code to ActiveMerchant responses

### DIFF
--- a/app/models/solidus/gateway/braintree_gateway.rb
+++ b/app/models/solidus/gateway/braintree_gateway.rb
@@ -150,12 +150,21 @@ module Solidus
       end
     end
 
+    def build_results_hash(result)
+      {}.tap do |results_hash|
+        results_hash.merge!({
+          authorization: result.transaction.id,
+          avs_result: { code: result.transaction.avs_street_address_response_code }
+        }) if result.success?
+      end
+    end
+
     def handle_result(result)
       ActiveMerchant::Billing::Response.new(
         result.success?,
         message_from_result(result),
         {},
-        { authorization: (result.transaction.id if result.success?) }
+        build_results_hash(result)
       )
     end
 

--- a/spec/solidus/gateway/braintree_gateway_spec.rb
+++ b/spec/solidus/gateway/braintree_gateway_spec.rb
@@ -87,6 +87,7 @@ describe Solidus::Gateway::BraintreeGateway, :vcr do
           capture = payment_method.capture(5000, auth.authorization, {})
           expect(capture).to be_success
           expect(capture.authorization).to be_present
+          expect(capture.avs_result["code"]).to eq "M"
         end
       end
 
@@ -151,10 +152,12 @@ describe Solidus::Gateway::BraintreeGateway, :vcr do
       auth = payment_method.authorize(5000, card, {})
       expect(auth).to be_success
       expect(auth.authorization).to be_present
+      expect(auth.avs_result["code"]).to eq "I"
 
       capture = payment_method.capture(5000, auth.authorization, {})
       expect(capture).to be_success
       expect(capture.authorization).to be_present
+      expect(capture.avs_result["code"]).to eq "I"
     end
 
     it "succeeds capture on pending settlement" do


### PR DESCRIPTION
This will also allow payment processing to store AVS codes on the `Spree::Payment` model.