### PR TITLE
Fraud hosted fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ And then execute:
     $ bundle
     $ bundle exec rails g solidus_braintree:install
 
+
+## Fraud detection
+
+This gem has support for the advanced fraud tools flow from Braintree, to activate
+fully the associated Braintree account must enable advanced fraud tools in the
+Control Panel.
+
 ## Usage
 
 This gem extends your solidus application by adding a `POST /api/payment_client_token` endpoint to you application to generate Braintree payment client token. This endpoint requires an authentication token in your request header.

--- a/app/models/concerns/solidus_braintree/inject_device_data_concern.rb
+++ b/app/models/concerns/solidus_braintree/inject_device_data_concern.rb
@@ -1,0 +1,18 @@
+module SolidusBraintree
+  module InjectDeviceDataConcern
+    extend ActiveSupport::Concern
+    included do
+      prepend(InstanceMethods)
+    end
+
+    module InstanceMethods
+      def gateway_options
+        options = super
+
+        options[:device_data] = order.braintree_device_data if order.braintree_device_data
+
+        options
+      end
+    end
+  end
+end

--- a/app/models/concerns/solidus_braintree/permitted_attributes_concern.rb
+++ b/app/models/concerns/solidus_braintree/permitted_attributes_concern.rb
@@ -3,5 +3,9 @@ module SolidusBraintree
     def payment_attributes
       super | [:payment_method_nonce]
     end
+
+    def checkout_attributes
+      super | [:braintree_device_data]
+    end
   end
 end

--- a/app/models/solidus/gateway/braintree_gateway.rb
+++ b/app/models/solidus/gateway/braintree_gateway.rb
@@ -68,6 +68,7 @@ module Solidus
             verify_card: true,
           },
         },
+        device_data: payment.order.braintree_device_data
       }
 
       result = braintree_gateway.customer.create(params)

--- a/app/overrides/spree/checkout/_confirm/braintree_security.html.erb.deface
+++ b/app/overrides/spree/checkout/_confirm/braintree_security.html.erb.deface
@@ -1,0 +1,9 @@
+<!-- insert_before "erb[loud]:contains('place_order')" -->
+
+<%
+# Currently we assume we only have one braintree
+# payment method. In practice this should be true and it simplifies the code.
+braintree_payment = @order.unprocessed_payments.find {|p| p.payment_method.class == Solidus::Gateway::BraintreeGateway }
+if braintree_payment %>
+  <%= render 'spree/checkout/payment/braintree_initialization', payment_method: braintree_payment.payment_method %>
+<% end %>

--- a/app/views/spree/checkout/payment/_braintree.html.erb
+++ b/app/views/spree/checkout/payment/_braintree.html.erb
@@ -1,4 +1,6 @@
 <div class="braintree-payment">
+  <%= render 'spree/checkout/payment/braintree_initialization', payment_method: payment_method %>
+
   <div class="braintree-cc-input">
     <%= image_tag 'credit_cards/credit_card.gif', :id => 'credit-card-image' %>
     <% param_prefix = "payment_source[#{payment_method.id}]" %>

--- a/app/views/spree/checkout/payment/_braintree_initialization.html.erb
+++ b/app/views/spree/checkout/payment/_braintree_initialization.html.erb
@@ -1,0 +1,7 @@
+<% content_for :head do %>
+  <%= javascript_tag do %>
+    braintree.environment = "<%= payment_method.preferred_environment %>"
+  <% end %>
+<% end %>
+
+<%= hidden_field_tag "order[braintree_device_data]", '', :id => "device_data" %>

--- a/db/migrate/20160426221931_add_braintree_device_data_to_order.rb
+++ b/db/migrate/20160426221931_add_braintree_device_data_to_order.rb
@@ -1,0 +1,5 @@
+class AddBraintreeDeviceDataToOrder < ActiveRecord::Migration
+  def change
+    add_column :spree_orders, :braintree_device_data, :text
+  end
+end

--- a/lib/assets/javascripts/spree/frontend/braintree/solidus_braintree.js
+++ b/lib/assets/javascripts/spree/frontend/braintree/solidus_braintree.js
@@ -18,6 +18,7 @@ Spree.routes.payment_client_token_api = Spree.pathFor("api/payment_client_token"
 
 var braintreeDropinIntegration;
 var cardSelector = "#payment-method-fields";
+var confirmForm = "#checkout_form_confirm";
 var paymentId;
 
 var getClientToken = function(onSuccess) {
@@ -59,11 +60,42 @@ var initializeBraintree = function(data) {
         selector: "#braintree_card_expiry"
       }
     },
+    dataCollector: {
+      kount: {environment: braintree.environment}
+    },
     onReady: function (integration) {
       braintreeDropinIntegration = integration;
+      $('form').find("input#device_data").val(integration.deviceData);
     },
-    onError: function(type, message) {
-      show_flash("error", message);
+    onError: function(error) {
+      var text;
+
+      if (error.type === "VALIDATION") {
+        text = 'There was a problem with your payment information. Please check your information and try again.';
+      } else {
+        text = error.message;
+      }
+
+      $('#checkout_form_payment').find(':submit, :image').attr('disabled', false).removeClass('disabled');
+      var errorDiv = $("<div/>", {
+        class: 'flash error',
+        text: text
+      });
+
+      if (error.details) {
+        var list = $("<ul/>").appendTo(errorDiv);
+        $.each(error.details.invalidFieldKeys, function (idx) {
+          $('<li/>', {
+            text: error.details.invalidFieldKeys[idx] + " is required."
+          }).appendTo(list);
+        });
+      }
+
+      if ($('.flash.error').length == 0) {
+        errorDiv.prependTo("#content");
+      } else {
+        $('.flash.error').replaceWith(errorDiv);
+      }
     },
     onPaymentMethodReceived: function(obj) {
       $("#payment_method_nonce").val(obj.nonce);
@@ -71,6 +103,14 @@ var initializeBraintree = function(data) {
       return;
     }
   });
+};
+
+var getDeviceDataConfirm = function(data) {
+  var collector = braintree.data.setup({
+    kount: {environment: braintree.environment}
+  });
+  $('form').find("input#device_data").val(collector.deviceData);
+  collector.teardown();
 };
 
 $(document).ready(function() {
@@ -82,5 +122,10 @@ $(document).ready(function() {
     // Attempt to initialize braintree
     paymentId = $("form input[type=radio][name='order[payments_attributes][][payment_method_id]']:checked").val();
     getClientToken(initializeBraintree);
+  }
+
+  // Attempt to inject device_data to confirm form.
+  if ($(confirmForm).length && braintree.environment) {
+    getDeviceDataConfirm();
   }
 });

--- a/spec/cassettes/Braintree_checkout/denies_a_fraudulent_card.yml
+++ b/spec/cassettes/Braintree_checkout/denies_a_fraudulent_card.yml
@@ -1,0 +1,276 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.60.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 25 Apr 2016 16:30:52 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"ebdb0f1c0fd3a67155160e55c7122742"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 28d4ba69-05a4-464b-b964-284efc8440f4
+      X-Runtime:
+      - '0.231296'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIADxGHlcAA6RV0W6jOhB936+o+r53jQm9i9R21SSFgIK7IYkBv4FNG4hN
+        cpcAga+/46TtdqXc1Ur3ASGZ8Zw558wMt9+OSl61+Y+62FV318Zf6Poqr/hO
+        FNXL3fV65Xz+ev3t/tMtl0VeHT4fdtu8uv90dXXbprLJ7/Pexyz2hzSyG6/c
+        9fOJvxFxuMtMf58rB+nzUMmGYdrzmb/PqkXxVPhFMCxG8KBA0ZIMDx1ZbYoE
+        Ezj3N2T6gpPV45GoBJGVKINpYBBMZVAGAxnINigfDTLQMoh0jI73OjJdo2eX
+        9CxyEIvC5yRe2EH5cCQF6sgE9YQujqTcDcF0ZwTFyAwGjoPp1iTD9kcwfegC
+        52jAuyfKkFyRXRJZKMZy+z3eF1lJrbx6tMRUmFksRmTqc7GCOyXrROTXaUSe
+        U0yt77E8PEXhP8J0utTcFKIkoxz4giZlhi2VRoJy1Wn+OzELOz7s2jmG2KU1
+        AN42UfZorvw+iWQjZr5kkdgIl5pJvG0SbB+eStCrtw+gd5m6DsQEba78hsTy
+        hq8kIqY4CPMFBYVdZq6UWaV1GO/nZnKcY9Jmiu2ZSfskDvcZHp3qgjx15lLt
+        z+CV+yxedgWLLJzGPsQb8tWv9/q8ogOfjnuIQQvITWO/Bt+LdBYiPgtu5r29
+        4e624dhpmOu3+cQquHLA9xC8oRVgS4Eda66gntUOkWnQZhHUhDcbiBnm5iW9
+        vfYNMz7p5dWecsBBirhB+2zi3Xhqg8RsPDwVX9skJgOLIddvtDzxiClKnUv3
+        4XxiYcA7ZP2feXPKF1mbbCah54nW8m+vupD7lcc8cpokOlrClSX/Q4z/0KZ4
+        Bs+Eu9H6Pq4xLUXsyxBqSdRRMsCHXAaDGO46Fjz1776d6lbhnpvjOonlUxIZ
+        Uvu7NseQf33u5XNv+fp+VtE6m8B9mG2hnDKnHzk/6H6QuescuHuUJ8+Xdscn
+        4F9FwSN/zEzNU/dZ+MtsaK1YDD0Rj2u2tGB+UCtcezjpDN4z+n98P8dd6F2Y
+        B1qm2DbExOqAf5dE3fs95krQgKDFB/w3/uBlnZnC07WDhohXVIJWwIvtubIb
+        6PFGPFrtSlEksN2n/U/tL8xbyxSDvWJJjSvgO9Sr9xp5n33AZsqpOV7DLHzg
+        uyZwT2PJreaWRc4A/Pu3vgt6PTuwh93jPlPio/7Dpb74MJtj2M8t1IKW0Xkn
+        cI13mkVi8Aq4KmItY9IusL2F8xtP0lU48e3z/pPNybc1hb73a6ZzKAbzQrRO
+        P3faa92X95ruGwY4RnvihpnyKnR3++X8L/p0++XXv9S/AAAA//8DAElGXWDc
+        BgAA
+    http_version: 
+  recorded_at: Mon, 25 Apr 2016 16:30:52 GMT
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <first-name>Han</first-name>
+          <last-name>Solo</last-name>
+          <email>han@example.com</email>
+          <credit-card>
+            <cardholder-name>Han Solo</cardholder-name>
+            <billing-address>
+              <first-name>Han</first-name>
+              <last-name>Solo</last-name>
+              <street-address>YT-1300</street-address>
+              <extended-address></extended-address>
+              <locality>Mos Eisley</locality>
+              <region>AL</region>
+              <country-code-alpha2>US</country-code-alpha2>
+              <postal-code>12010</postal-code>
+            </billing-address>
+            <payment-method-nonce>bb56ebba-9e09-441e-866a-af336aac9cf5</payment-method-nonce>
+            <options>
+              <verify-card type="boolean">true</verify-card>
+            </options>
+          </credit-card>
+          <device-data>{"device_session_id":"dd15c7f582acef102b0ed6c7b7321522","fraud_merchant_id":"600000"}</device-data>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.60.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Date:
+      - Mon, 25 Apr 2016 16:30:55 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 9b05a4f7-b396-4e26-8d61-7b96a23c00e5
+      X-Runtime:
+      - '0.239868'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAD9GHlcAA6xWS3PjNgy+51dofGoPXD1sOY9RtN1DH4f20iSdaS8diIJi
+        NhKpJals9O8X1NuR0zqd9ckEPhAgHh+UfHypSu8ZtRFK3m7CD8HGQ8lVLuTj
+        7ebh/id2tfmYXiRQC4ZaK800mlpJg+mF5yWdyLi/08GzbY23G9Aa2o3fofwZ
+        ltSgoRoteGOsqlD3RxLk+Cw4MoPGxcNEnuZ5GPPLIr6KgGMRBlEWYL7nl9nl
+        NgrjKEr8tc14W6GhyRndzw8grdPsA/dL/LVmshHaWCahwvQXkISczyOkhFFy
+        p0qV+PN5RGAFokzp6h/wBaq6xA9cVZSGTjyCuMZcWMZBT96dlI4HVeaopyC8
+        3s1rzWyTibKkejHIc6qOmTVnvee8N3UoYzWinfz8ec/CrUvnK/nSBF8syhzz
+        UelJUd5urG6wb445AsWhFLZNf1PG+1GYElsKYxQukRofqdDpp18Tf/i71HLV
+        SKtbRj2MDMr6AFH6cEfpOyFf2tXKWCg7dRpGQUjPWormbPtvppuau62Q+qlC
+        e1A5k0pyTLMs3mOWAbvG4JrtdiGyq/0eGBTb7R6AX/MiJl+nTOebVW3pocep
+        pakVRds3kEto4i8li4BXxt92zv7npPmrASDRghBcTkauSCryCo+Y/gwWv0Dr
+        /Y7/ILeY33idg8QfARdjYgQHO/UGdS7YxqSPvfnfejB3rdspBj56fp74rSv7
+        ulsTeDavmPDfkIsWOgt/PEn/aTK8h/XvcWXRCIZePWTlTX1vPpUFeDcerjym
+        pghcPteq3qjWilNsZyTgBNISH6QP8kmqL9L77nuq8RuY/gZyGmv7+eWQ+JP/
+        Yfy+LWMTP9cg21Ps9E7WO4vxzmO7t5nuTLaayLB764MU1PLeHXU8Gk8V3icq
+        Mo3JzI1zSiaWGydjvawSq55QnnxdJmS6o/EPQ3ePPK7DLg1jpxgOU6h0NXPf
+        DukfwkC/7vrznNha6G6oWaWkPdDDaae+Fp5Atwg6jYIoOIJ30sn7QDzM1aDj
+        jW5nrKTLaN+1ppNGis8NMtlUGalETmRPJEVUh7ssCq7iPNzut5xf7sLL6ywr
+        9mFYcOC7uEj8N02nbtBYAw3IMFhuqnrBCDgglPZAoeGMWcjmz69M2BnRHydl
+        o6mWNKaPTUkdtPC20iymyvGIgHIGL2RT+NBqVS4wo2AECGMat3EzkE8z6kj6
+        uuNVwZwe3Bpd+F4r5xyqvOEdzy3SOMnGBbXaWSRxb2Zghy/fnI5WVLihlgv3
+        LNixKL4P9zfb4CaO/+quGAyGG5o6f98Ns0G/J4/3XeKf+lj/CgAA//8DAJ2B
+        +kvpCwAA
+    http_version: 
+  recorded_at: Mon, 25 Apr 2016 16:30:54 GMT
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.60.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 25 Apr 2016 16:30:56 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"bd3eadd6ecaa46e38bf599da7c376639"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 242ac731-45c2-4d3f-b8f4-afde52e4e95c
+      X-Runtime:
+      - '0.224942'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAEBGHlcAA6RVW2+bShB+z6+I8t4WFpNTpCSVb2CQWdfYXmDfYJfEwC72
+        Keb6689gJ2kq+VSV+oCQltmZ+S4zPHxrpbitkx9leige79TPyt1tUrADT4uX
+        x7vd1vz09e7b080DE2lSnD6dDnlSPN3c3j7UkaiSp6RzEA2cPvKNys4O3XLq
+        7HngHWLNOSbSVIZzT4qKItKxhXOMi3W6Sp18tRV56IeNu+UZ3Y6b1SzX3WyS
+        UR9n1JqP3H7XujMzp7N5h9FcDbM5ohCPLTMP+1yDGB1vxyrNxojO1o3bv6jP
+        Fu6obyrU957DYG242bjFqdLgqdJhsm5xdujd2UHF6ahdzdYqnrk97u0f7mzc
+        uGarwrvDUhVM4kPo60qARP49OKZxRvSkmOt8xrU44CM8cxiHnt2MNtx3ysjH
+        zxEi+vdAnFa+9y/XzCbS9inP8CgBvMBJFiNdRj4nTDYD/gNfeA3rD/USQexG
+        76FeHkpjtJROF/qi4gtHUJ/vuUW0MMirEBmnVbZW3M44Ad9ZZJkQ49aJdCoc
+        iHu2FQrW+IlrL4qbGllsCREXAw+T41IL2yXCdSzpkWqkCwPvGKPRuS/IU8YW
+        GfTp7ewYB5smpb6OosCBeFW86vXen502aYjaI8Qoa8hNAqcE3dNo4Sls4d4v
+        O2PPrLxiyKyo5dTJVE+ZNEF3D7QhBdQWHJn6UkI/24MCGtSxDz2h/R5i+qV2
+        jW+7fqsZnPmyS1uaPUNEYSrp4ql9b8u9wheTfpV+rcMA9zSAXL/h8owjIEpk
+        XrsP51Md/Kaf4u7PtDnn8/V9vBDgeTxw+Y9dXMn9imPpm1Xotzq3RMb+sMb/
+        cJM+g2bc2g/8zneIZDxwhAe9hLIVFOpDLpVCDLNMHZ7yd9/OfUvvyLRJGQZi
+        FfqqGPTdaRPIv7t4+eItZ7gfF6SMp3AfZptLM0vIR8zjwQ8iscwTs1px1nxj
+        NGwK+hUENHImVBtwDj7zfpmNgSsagCeCSUk3OsyPUnPL6M88g/aU/I3ul7gr
+        3oV5IFmEDJVP9QbwN6HfvN+jlgAOsLL+UP8NP2hZxhq3h96BQ4UVRABXgIse
+        mTQq8HjF53q9lUThyOii7if3V+atppLCXtHFUJfDd+h32Gv4ffahNpVmydAO
+        ZuED3h2Ge0MtkQ/YYt/sAX/35ju3G2YH9rDVHmPJP/LfX/PFh9mchLBDoBdl
+        4192AhvqnWcRq6wArBLrmwDXa2TkcH5vC7L1po5x2X+iOuu2I+B7p6RDDklh
+        XvDA08+d9tr39b02+IZCHbU+Y0NU2oXy+PDl8i+6efjy61/qPwAAAP//AwDU
+        Q4g73AYAAA==
+    http_version: 
+  recorded_at: Mon, 25 Apr 2016 16:30:55 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/Braintree_checkout/expiration_and_cvv_are_required.yml
+++ b/spec/cassettes/Braintree_checkout/expiration_and_cvv_are_required.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.60.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 04 May 2016 19:35:24 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"ee4d2d3b6ba2c1dfcf00fc7a0987c572"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 200f74ec-aafd-4a41-973b-5c2eb07e23cf
+      X-Runtime:
+      - '0.237916'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAPxOKlcAA6RVXW+bShB9z6+I8t5bvJjcIiWpYidgkFnXGO/CvsEuCeBd
+        7FvM56+/g92kqeRbVboPCGmZnTPnnJnh7mun5HWTfq/yfXl/M/lLu7lOS74X
+        efl6f7MNrE9fbr4+XN1xmafl8dNxv0vLh6vr67smlnX6kPYuYqE7xNSsnWLf
+        L+duJkJ/n+juIVWWNp77StYMkZ4v3ENSrvNV7nSMen1EiWTF67AKnN4bmMTF
+        K4qK3RQP2Q4X26mHPC2i3uAN2w5TN/OedmhlO533tJ6uArHzgmcNU6dntmdE
+        RSZfbNwzammM+i9RuDa94rHDudbiDTzWulsF+wEH+x7PpwMeoinka3Gw/u49
+        Pbae1U3g3WM1kVzhfUQNLURy9y085ElBjLR8NsST0JNQTPGTy0UAdwrWCupW
+        McUvMSLGt1AeV9T/R+hWG+tZLgo8TYEvaFIkyFAxFYSrFvi7e7HwWz7smyWC
+        2I0xAN4uUuZ0qVzQRdZi4UpGRSZsokfhro6QeVwVa83rzSPoXcS2BTFekyq3
+        xqG85YHUsC6OQn/VvNwsElvKpBx1mB2WetQtEW4SxQ5MJ30U+ocETU91QZ4q
+        scnoz+AUhyTctDmjBopDF+In8uyX+16fk7d5hLoDxGhryE1CtwLf83jha3zh
+        3S57M+P2rubIqpntNuncyLmywHcfvCElYEuBLGOpoJ5gr+Enr0ko1ISyDGKG
+        pX5Jb6d5wwxPejmVo6yBI6LxCemTuXPrqEwTi9mwyr80UYgHFkKu32h54hES
+        LbYu3YfzuYEA75j0f+bNKR81smQhoefxqOXfTnkh9w8eS2rVEe0MYcuC/yHG
+        f2iTv4Bnws5GfZ+3iBQidKUPtUSqkwzwIdeEQQy3LQOe6nffTnUr/8D1WRWF
+        chXRiRz93eozyL899/K5t9zxflKSKpnDfZhtoawiJR85P479IFPbOnK7kyfP
+        N2bL5+BfScAjd8b0kefYZ/4vszFqxULoiXBWsY0B86M1wjaHk87gPSP/x/dz
+        3IXehXkgRYzMiZgbLfBvI9q+32O2BA2wtv6A/8YfvKwSXThj7aChxksiQSvg
+        xQ5cmTX0eC2ejSZQRBPI7OP+p/YX5q1hisFeMeSIK+A71DvuNfw++4DNlFVx
+        tIVZ+MB3i+HeiCV3I7eEWgPw79/6zuvH2YE9bHeHRImP+g+X+uLDbM4i2CFQ
+        i7ah553AR7zTLOIJL4GrwsYmxM0amTs4v3UkCfy5a573n6xPvm0J9L1bsTGH
+        YjAveNTp5077UfflvTb2DQOcSXPihphySu3+7vP5X3R19/nXv9S/AAAA//8D
+        AHdVbl3cBgAA
+    http_version: 
+  recorded_at: Wed, 04 May 2016 19:35:24 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/Braintree_checkout/unsuccessful_credit_card_transaction_amount_2000_.yml
+++ b/spec/cassettes/Braintree_checkout/unsuccessful_credit_card_transaction_amount_2000_.yml
@@ -1,0 +1,400 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.60.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 04 May 2016 18:03:57 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"b275de874c0c26753f98e879a2ee1462"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 26c82bd4-8eed-4384-a2e9-d408dba70b66
+      X-Runtime:
+      - '0.221783'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAI05KlcAA6RVXW+bShB976+I8t5bWExukZJU8QcYZNY1thfYN9glMXgX
+        fIsBw6+/s3aSppJvVenK4sHL7Jw558wM999OUty02Y86r8qHW/0v7fYmK1nF
+        8/Ll4Xa7sT9/vf32+OmeiTwrj5+P1T4rHz/d3Ny3iWiyx6z3EI28IQmtxi2q
+        fjHxdjwKqtTwDpm0NXUeSNFQRHo29w5pucqXuZf7w2xEp1jEYWz4aNv7zkzD
+        U9fww5kRDy8jXMC7gqEYfv70qYtDssOFq/ubF0Q3KwMXMVo6286X9h5iC+pQ
+        +ezgnoa2RsPgOY5Wll88nXCudXgNj706LadV5w+VjvuR7hdM96ds5G/2P1R+
+        3z7B/6ceS10wias4NLUIif336JCnBTGzcmbyKTfSiI/w1GN8A3cK2vHQq5MQ
+        PyeImN8jcVyGwT/csLvE2OW8wKMM+IImRYpMmYScMNkp/hWfBx0bqnaBIHZt
+        DoC3j6U1Wkivj0PR8LknaMh33CFGHO2bGFnHZbHS/N46gt5F4tgQ47eZ9Boc
+        iTu2ERo2+JEbL5qfW0XqCJGWSofxYWHEpwXCbSrpgRqkj6PgkKLRuS7IU6cO
+        Uf4MbnFIo3WX09BESeRBvC5e/Xqvz827PEanA8RoK8hNIq8G3/NkHmhs7t8t
+        emvHnH3DkN1Qx2uziZkzaYPvAXhDSsAWHNnmQkI9mwo899s0hJrQbgcxw8K4
+        prfbvmFGZ73c2pX2wBDRmE76dOLeuXKn8fl4WOZf2zjCA40g12+0PPOIiJbY
+        1+7D+cREgHdM+z/z5pwvNHfpXEDPY6Xl3255Jfcrj0VoN3F4MrkjCvaHGP+h
+        Tf4MnnFnp/SdbREpeOSJAGqJ5UlQwIdcOoUY5tgmPPXv3p3rlsGBGeM6jsQy
+        DnWh/N0aY8i/vfTypbc8dT8tSZ1O4D7MNpd2kZGPnJ9UP4jMsY/MOYmz52ur
+        YxPwryTgkTemhuKp+iz4ZTaUVjSCnojGNV2bMD9ayx1rOOsM3lPyf3y/xF3p
+        XZgHUiTI0vnE7IA/7J3u/R51BGiAtdUH/Df+4GWdGtxVtYOGGiuJAK2AFz0w
+        aTXQ4w2fme1GEo0jq0/6n9pfmbeWSgp7xRQKl8N7qFftNfw++4BNpV0ztIVZ
+        +MB3i+GewhJ7xS0N7QH492995/dqdmAPO6dDKvlH/YdrffFhNscx7BCoRVuH
+        l53AFN55FrHOSuAqsbmOcLtC1h7O71xBNsHEsy77TzRn37YE+t6rqcohKcwL
+        Vjr93GmvdV/fa6pvKODo7ZkbotIttYf7L5dv0af7L79+pf4FAAD//wMATUIw
+        KdwGAAA=
+    http_version: 
+  recorded_at: Wed, 04 May 2016 18:03:57 GMT
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <first-name>Han</first-name>
+          <last-name>Solo</last-name>
+          <email>han@example.com</email>
+          <credit-card>
+            <cardholder-name>Han Solo</cardholder-name>
+            <billing-address>
+              <first-name>Han</first-name>
+              <last-name>Solo</last-name>
+              <street-address>YT-1300</street-address>
+              <extended-address></extended-address>
+              <locality>Mos Eisley</locality>
+              <region>AL</region>
+              <country-code-alpha2>US</country-code-alpha2>
+              <postal-code>12010</postal-code>
+            </billing-address>
+            <payment-method-nonce>9ab3d281-9300-4e01-908b-fe21e0d0a30b</payment-method-nonce>
+            <options>
+              <verify-card type="boolean">true</verify-card>
+            </options>
+          </credit-card>
+          <device-data>{"device_session_id":"c9f24a7149bf37858d70cfd9d678bebd","fraud_merchant_id":"600000"}</device-data>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.60.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 04 May 2016 18:04:02 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"f7223d2129f36d863f67c7a1f2b7c96c"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - fc6b3eb9-dfcb-47e4-b0d5-574519adf416
+      X-Runtime:
+      - '1.189160'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAJI5KlcAA7RY227jNhB9z1cYflck2fLaCRSlAdqiKLrFAkkKdF8WtETb
+        3EiklqQce7++Q0qUKMkXOUnzFM6cIYec27HC+12WjraYC8Lo3di/9sYjTGOW
+        ELq+Gz8//e4sxvfRVRgXQrIM8+hqNApJEi28YL4I5vPQhYWSgS7eICodWP9c
+        0tn+548bOX/NXnfBJHRtrUKvCBfSoSjD0R+Ihq61VuoUmdUjS1noNmuljVmW
+        I7ofUZLejSUv8NjVcpwhkkZwzC94h7I8xdeADN1SrAD5hlHcM1uhXU/2ipeC
+        yD425hhJnDhIjuQ+x3fjBJaSZHgcTTz/k+PNHC948he3XnDr+V9DtzHQ9kWe
+        DLefgH1jUJ6vw+CsCE4TUbuUEOnEiCei2hRxjvZjpW3rSwnIliRNIcAOShKO
+        hTDyMrTx1gS1kpnYO62429IGezqwFehkeM2hh4NcaYXkGMva/3+fHH/qeaHb
+        kTcGeCcxTdRDlqoj+6YsRimR++gzE6PfiEjxHtwzwgbH8RrqJXr4K3Srfxtd
+        zoREqQM1hCMfogpu2SL7igWVfK/FDkrzDZpEz4/wsgfkp6ymYPVwyGx6zIwW
+        EDgSR4vA69gZTd9Qx+eZQlUko0cJSSlGbDV60HDU7NIN4/sKptrlorLxe2Wj
+        93CPJD0UA40CX/0pTB3JUFWMo46L/iFC3bBe24gNSxMoApPxozKju5ragmWq
+        FRKUwlO+UPZK1cvVsgZWPiZbOUSIAtEY2/i+sjZ8/3MPL/cGqSpEqirQ6duT
+        GnyCl0Q2FymXjXKFitT4vWQsxYiOI1WiCqqVDbjgECoHaq9Ilf/Wpl2NMcG7
+        nHDtj5MxKjdQmzAbusID6D1GHF5v4rXgWtpCQ110fF+hVODKyvJkg1EqN5Ai
+        VlAtmYGRDK2xU3AYaVLm4tZ1kRBYiuslR4SqRreGC76ivRpzbo72GabyW4bl
+        hiXfUrZm7hby9jqn63tMt4QzqgB3AtFkyXbQ4+v96xMhnVSFLBF9aVxrSQ1U
+        t+wgKqumWhgduMJZamW4EdQAjnNErKAZgQGIYiliTnL10u2hVjfrULIXTKP5
+        ehJMYciXK6MrKPlR6Ga21BkL9yYwM3m0WM6mM28xu1kEeJLMggmOk7k/9QMf
+        e95sEkPnOGZa7/0BvWiLacYckbwcyZhab1lwcKOsp0NjvgdqxHpcIlmIqNTj
+        RM1JLbAx8XYLVSNy2B+Xk+oz1HJPaJugrXAw54y3MYdna4W3RmH/uNOA7lbt
+        YX94t5MYe8OqlgDxHce6wqEzCkaPXqamtCjWHVk1RgGJjC22a6ls05yzGLzp
+        vlvke4rDHNOe2UECxYkectBsVYSPIexdwK3vs8lMxG3C1xBEWzaQ3GngAIJX
+        5twpkldl7mVETxsNI3ulp8MIn8aeIH1lUAYSv+rq76BVFp1p13Cf61eaE92y
+        DvlBGmRH9HC/N2efo0t1cC6Yw32b89PY+HMZObFucRGlq+z+x4ljsuvM0Kxg
+        w8hFBT5FyAzkYqZlXnIQ1TWXO0MZKthwglI78TYiXb85S4pY92/r2WtZqx6P
+        1N7H/AL6GN6h9+FEvDigQd23TaIvf3/55P06+/qnP7vpjgSdLTERugOWU0Yl
+        TCVpvcSBExSl6XOTtrTq4r2XbAk0KKz6Oj74waP7+673SeOCXzjnJ975WXdq
+        yl043wZNtmEz7fg0GzjH3vL54k0fL9746eI9E/ZDfke/u2CBwTbhrxcYlk2y
+        Rlf/AQAA//8DACn7genCFQAA
+    http_version: 
+  recorded_at: Wed, 04 May 2016 18:04:02 GMT
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/transactions
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <transaction>
+          <order-id>R369273730-W7P26W87</order-id>
+          <options>
+          </options>
+          <amount>2500.00</amount>
+          <channel>Solidus</channel>
+          <shipping>
+            <first-name>Han</first-name>
+            <last-name>Solo</last-name>
+            <street-address>YT-1300</street-address>
+            <extended-address></extended-address>
+            <locality>Mos Eisley</locality>
+            <region>AL</region>
+            <country-code-alpha2>US</country-code-alpha2>
+            <postal-code>12010</postal-code>
+          </shipping>
+          <payment-method-token>7g243m</payment-method-token>
+          <customer-id>80478477</customer-id>
+          <type>sale</type>
+        </transaction>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.60.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Date:
+      - Wed, 04 May 2016 18:04:04 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 16baa6d2-73ec-4a3d-90ac-3f2cc5f87bef
+      X-Runtime:
+      - '1.087636'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAJQ5KlcAA+xYS3PjNgy+51d4fGckv2JvRtF2Z7adtrO7kzab7rSXDC3B
+        NhuJVEnKsfvrC0qiXqYc59JL65MFfARJEAA/MHh/SJPRHqRigt+NJ9f+eAQ8
+        EjHj27vx49cfyGr8PrwKaMYISCkkkaAywRWEV6NRUIiU+Vt/jPQxg7sxlZIe
+        x16B8hpYkFFJUztCS8oVjTTOXUpQJmQMkrA4/HV28266nC1nPvm2vJ/efFst
+        A6/W1vDMjFYjzpK7sZY5lHMWOpqKnOtwuvD9a98PvOrbqqMd5RyS8EEkLM5V
+        4FmBBagdyzJ0hBWgaMOk0oTTFMIfKQ+81ncDSqiVoWkReM13g1FaAmhC4xgd
+        qsLfv5LJzKyxJ28GwEEDjyG2KteOzdwiognTx/CzUKPvmUrgiAuwwgYnYWu8
+        /uFT4FV/G11k3CSPBMMACE2yHZ2Gjw/oH4e8GZUJpWlSKMPJ1J/gZtoi61Sv
+        71UMiWMKXJMU9E7ERItn4OFyO53PUjThUtYnmCst0jIgVv58uZovMUbaUos0
+        QRkqmkDgFX/L+PN6AWims+EZpOhkuoXwXooI/wo5+ghRwjjEgWd1V64gDnDe
+        zXIRrXaBZ5eA5011rsLMGnuKa2OV6urMQqNcSkzLI2FKlO58fPhodtoXX70a
+        +LgvaQIdYywqDtS4SWUYdWZbp6pq+fmaOLSnQRikGOzo+8vAb0n2IJJAtUkA
+        XdWYGD81S2EcYrjdEH9B/PnXyerWn9/6sz/QPfWAykKexZdbmKOFZkB9EGVs
+        1YHVibxWwL1eKF4vE5iIaUb50VncIKUsCdHF38GBplkC14jGUluILegF1opp
+        cBrIdoK7NRt6cJyV1917sGZJ0k5j3Hy0/3d98LYielEJvayADpfPS8ugraXF
+        Xh85HlI8esBCAGokNqMP6GYW0abk9lzy5vrsGDPDMR9cg2buQTwvFhWu5n5v
+        lNVUcdIJDPTUJuexO/1rnYM11Go8r1aJdRvCsq0ZuliB1gkUF0Z3jHsCmuOl
+        Itnfl0zRMr2mOtoNoPqXmwv1f2r8V1OjGx7VbUI2DJJY1UG5Vz2qXZhyBJtB
+        thzYxYef8d4/C2iMdIPCbecsptrOft+T/4TuOBGW4C0e6As9ou5PKNMOb2sl
+        uCu7LWkiNmFpMWDALQ28O6+hQxhxA9rBsRpzw0kCh7CVX+OYmVWi70+BxVpG
+        txgR52Glqb1gkTm8DYYF4jCm1iBdG88N58JllMRpEKfpgZSUcEAJB0gzy5HW
+        QiRA+Tjc0EQZWloDGl6GeyARlS2+3SHxXda+ZjycT8zP3BW8W/DmYamoPup0
+        Q+OkIMS/MWWSv/5uKljGZBkXqeB6hxUG2VBf6EAfgUqkf1O/Ay+kJ32GKXYF
+        0S9qyom0vdqdSIpDqEr8qCzifU19TaTYTpBcIqPTOlO3nkcV3jjqei0p4yb1
+        qnwxLM82RU9lU/SUiK3w9uiX64xv3wPfMym4AdwpyuO1OCArq+3XxVhCRpGs
+        PfJnLl64CedSYAE7oIne4YKhwbRkFhbDmukGUX7WylziCWPobvPEEOkWrq9p
+        XWqmd8DbvAG3ZK2mUYqkhbGC2qNK5Vhp8bLmzw2qI+3XcrEhRk95BO25T5WN
+        D0WcR0Wb1HJjLbOwnLO/cqjyERV4MgxrvgxX68Vs4a8W71ZzmMaL+RSieDmZ
+        TeYT8P3FNMIGZGiotb0Hngqi4ueBbK31NYvvZ2vVmpIdw3CWxw5RatGJAgNo
+        rj5dk+bYO6EqzS7sp2p85yXkos64LKpnX3SMqxX6Jk4p3wJeWWVXW8haa24x
+        PSWwZEJIM9Z5C7Dy5s3iZPu1rHKbLcEJHeKP+VpFkmVnGGYL0SqWBZkmGdII
+        ERMkacQ42cnPelhcoNQDaFz+yWzmyiLmLc1FlWOmikwY0EJpSzSBacrbG/tO
+        LE+ulfaNI8M0Dx+404GYr/X2gjr70IfMXu7NBbsBGL4WzRrECykP3aFH/6xz
+        qcoGIQaNXXjDrrvKoeNrdRhDy+iiTp5/Lh4AB+MCvBHk0GJM54XBjcTUbTSP
+        ImebgMc16Anjhyw3PN4VQ/alj3GkmnnZw5kLvixYT6ZgNc+BfVCfvbU23aV5
+        bdo2CLrEWkH1XrPW4oOSqWdz9rT9YHL/5f7G/+XTp8XHm587TydYA5l5kg8r
+        ummyoJJUbu7ZC/QOix3BrDfBD+igjeifTu+9E8un41X/HwAAAP//AwBN50QE
+        EhgAAA==
+    http_version: 
+  recorded_at: Wed, 04 May 2016 18:04:04 GMT
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.60.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 04 May 2016 18:04:05 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"2000db203cafcccbf457987ae3d6f2f5"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 3f6c5282-e70a-49e5-af8b-097011e31550
+      X-Runtime:
+      - '0.228220'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAJU5KlcAA6RVXW+bShB9z6+I8t5bvJjcIiWp4g8wyKxrbO/CvsEuCeBd
+        7FvM56+/g92kqeRbVboPKySYnTPnnJnh4Wur5G2dfC+zQ/F4N/pLu7tNCn4Q
+        WfH6eLfbWp++3H19unngMkuK06fTYZ8UTze3tw91JKvkKelcxAK3j6hZOfmh
+        W07dVAT+IdbdY6IsbXjvK1kxRDq+cI9xsc5WmTNmuZWyWZpjSvYeZTlTOx3b
+        Xs9yroX9rsM2ST3l6autrzzFlEe9Ptzy8Wr7CsfRPXvee3Tespm1D6mDsD0f
+        vdi4Y9TSGPVfwmBtevlzizOtwRs41rpdzQ4NHs5m3OF+jXC+bvH29bs3e248
+        qx3Bs8NqJLnCh5AaWoDk/ltwzOKcGEkxN8RM6HEgxnjmcrGFOzlrBHXLiOKX
+        CBHjWyBPK+r/I3SrifQ0EzkeJ8AXNMljZKiICsJVA/zdg1j4De8P9RJB7Mbo
+        AW8fKnO8VG4XUlmJhSsZFamwiR4G+ypE5mmVrzWvM0+gdx7ZFsR4daLcCgfy
+        nm+lhnVxEvqr5mVmHttSxsWgw+S41MN2iXAdK3ZkOunCwD/GaHyuC/KUsU0G
+        f3onP8bBpskYNVAUuBA/khe/3Pf6nKzJQtQeIUZbQ24SuCX4nkULX+ML737Z
+        mSm39xVHVsVst06mRsaVBb774A0pAFsKZBlLBfVsDxqeeXVMoSaUphDTL/Vr
+        ejv1G2Zw1sspHWX1HBGNj0gXT517R6WaWEz6VfalDgPcswBy/UbLM4+AaJF1
+        7T68nxoI8E5x92fenPNRI40XEnoeD1r+7RRXcv/gsaRWFdLWELbM+R9i/Ic2
+        2Qt4Jux00He+QyQXgSt9qCVUrWSAD7lGDGK4bRlwyt99O9et/CPXJ2UYyFVI
+        R3Lwd6dPIP/u0suX3nKH+3FByngK92G2hbLyhHzk/Dz0g0xs68TtVp4935gN
+        n4J/BQGP3AnTB55Dn/m/zMagFQugJ4JJyTYGzI9WC9vszzqD94z8H98vcVd6
+        F+aB5BEyR2JqNMC/CWnzfo/ZEjTA2voD/ht/8LKMdeEMtYOGGi+IBK2AFzty
+        ZVbQ45WYG/VWEU0gs4u6n9pfmbeaKQZ7xZADroDvUO+w1/D77AM2U1bJ0Q5m
+        4QPfHYZ7A5bcD9xiavXAv3vrO68bZgf2sN0eYyU+6t9f64sPszkJYYdALdqG
+        XnYCH/DOs4hHvACuChubANdrZO7h/b0jydafuuZl/8nq7NuOQN+7JRtyKAbz
+        ggedfu60H3Vf32tD3zDAGdVnbogpp9AeHz5f/kU3D59//Uv9CwAA//8DAPs2
+        iK/cBgAA
+    http_version: 
+  recorded_at: Wed, 04 May 2016 18:04:05 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/Braintree_checkout/unsuccessful_credit_card_verification.yml
+++ b/spec/cassettes/Braintree_checkout/unsuccessful_credit_card_verification.yml
@@ -1,0 +1,192 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.60.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 04 May 2016 18:03:52 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"2c60f71f9a0b4b1b5a6a021212da98f2"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - bcc8d43d-8fee-4012-be46-8d30ab09d6cb
+      X-Runtime:
+      - '0.237791'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAIg5KlcAA6RV32+bOhR+719R9X0bmNI7pLZTkxSCFZyFJAb8BjZdABty
+        R4DAX38Pydp1Uu40aQ9WIvv8+r7vnMP9l6OS1236vc6q8uFG/6jdXKclr0RW
+        fnu42W7sD59vvjxe3XOZpeXhw6Eq0vLx6vr6vo1lkz6mPUYsxEMcWI2bV/1i
+        inci9KvEwPtU2dp47yvZMER7Psf7pFxly8ztPRQNzCE7bygMb/M0kLzQow2T
+        EfIV28iCOLSIchv+2zviuObSwXmkPMNTz300bJGHsCIOzshgy+XMH9/0F4f0
+        LLA1FvgvUbiyvPzpSDKtI2s49uq4nFWdN1S6t741l7OnozfjcLbfvdlT59lH
+        HX57onTJFamiwNRCJIuv4T5Lcmqm5bMpZsJIQnFLZpiLDfjkrBMBruOAvMSI
+        ml9DeVgG/r/CsLvY2GUiJ7cp4AVO8gSZKg4E5aoD/LgSc7/jQ9UuENiuzQHy
+        FZGybhcK91EgGzHHkgViJxxqRGHRRMg6LPOV5vXWAfjOY8cGG69NFW5IKO/4
+        RmrEEAdhfNO8zMoTR8qkHHmY7BdGdFwg0iaK7ZlB+yj09wm6PdUFcerEoaM+
+        g5vvk3DdZSwwURxisNflWS/8Vp+bdVmEjnuw0VYQm4a4Bt2zeO5rfO7dLXpr
+        x52i4chumIPbdGpmXNmguw/a0BJyS4Fsc6Ggnk2lkZnXJgHUhHY7sBkWxiW+
+        3fY1Z3jiy61dZQ8cUY3rtE+m7p2rdpqYT4Zl9rmNQjKwEGL9hssTjpBqsX3J
+        H+6nJoJ8h6T/M21O8QJzl8wl9DwZufzHLS/E/oFjEdhNFBxN4cic/2GO/+Em
+        ewHNhLMb+X3eIpqLEEsfaonUUTLID7F0BjbcsU049e/eTnUrf8+NSR2FchkF
+        uhz13RoTiL899/K5t/Don5S0TqbgD7MtlJ2n9D3mp7EfZOrYB+4c5UnztdXx
+        KehXUtAIT5gx4hz7zP9lNkauWAg9EU5qtjZhfrRWONZw4hm0Z/RvdD/bXehd
+        mAeax8jSxdTsAH8XBd2bH3MkcEC01bv8r/hByzoxhDvWDhxqvKQSuAJcbM+V
+        1UCPN+LZbDeKagJZfdz/5P7CvLVMMdgrphzzCniHese9Rt5mH3IzZdccbWEW
+        3uHdEvAbc8lixJYE9gD4+9e+8/pxdmAPO8d9osR7/odLffFuNicR7BCoRVsH
+        553Ax3ynWSQ6LwGrIuY6JO0KWQXc37mSbvwpts77TzYn3bYU+h7XbIyhGMwL
+        GXn6udN+1H15r419wyCP3p6wIabcUnu4/3T+Fl3df/r1K/UfAAAA//8DAD3i
+        uhPcBgAA
+    http_version: 
+  recorded_at: Wed, 04 May 2016 18:03:52 GMT
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <first-name>Han</first-name>
+          <last-name>Solo</last-name>
+          <email>han@example.com</email>
+          <credit-card>
+            <cardholder-name>Han Solo</cardholder-name>
+            <billing-address>
+              <first-name>Han</first-name>
+              <last-name>Solo</last-name>
+              <street-address>YT-1300</street-address>
+              <extended-address></extended-address>
+              <locality>Mos Eisley</locality>
+              <region>AL</region>
+              <country-code-alpha2>US</country-code-alpha2>
+              <postal-code>12010</postal-code>
+            </billing-address>
+            <payment-method-nonce>3c3cfcc3-d0ce-4064-a46a-91a2ecc9754d</payment-method-nonce>
+            <options>
+              <verify-card type="boolean">true</verify-card>
+            </options>
+          </credit-card>
+          <device-data>{"device_session_id":"f29573944537e6a65b299159a0842e79","fraud_merchant_id":"600000"}</device-data>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.60.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Date:
+      - Wed, 04 May 2016 18:03:55 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 0c57c406-a2f7-457b-95ae-f9cf0bce886f
+      X-Runtime:
+      - '0.522538'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAIs5KlcAA6xXS2/bOBC+51cIvrN6WJbtQlG3wO6ihzYokGSBzaWgybHN
+        jURqScqN/32Hetuyi6RoTuY3Dw7n8Y2Sfngpcu8A2gglb2fhu2DmgWSKC7m7
+        nT0+/E1Wsw/ZTUpLQUBrpYkGUyppILvxvLSGjPvZHzx7LOF2RrWmx5lfa/mD
+        WlpSTYvOglXGqgJ0c0SAw0EwIAaMi4cInm2j9WI5X8fxYr6EhCaLTbReh4s1
+        DVZxBMt16k9tOm9bTStO0D/bU2mdJAncX+pPJb2N0MYSSQvIPlGJmsO5U8lp
+        h9yrXKX+cO40oKAiz9D1H/BCizKHd0wVmIYa7pSYBi4sYVT3tzsUj3uVc9B9
+        EF5zzblksNmIPMd6Eco5VscMkle953VvqrWM1QC2v+ffBxLOXTrP8LEJvFiQ
+        HHgn9KTIb2dWV9A0xxCBYjQX9ph9Ucb7S5gcjhhGB441Neyw0NnHz6nf/hxL
+        maqk1UeCPQyE5uWeRtnjPabvAj62K5WxNK/FWRgFIT5rDA3Z9q+mG5v7WAD2
+        UwF2rziRSjLI5mzOtozNCQ+wTeMgiQmNE0rWIY2AsfVyEXO865Lp4FmVFh96
+        mlqcWrE9Ng3kEpr6Y2QU8MT4987ZL06aPxkAhEaE4HLScUVa4K10B9mfyrtT
+        1vukpNKp36E3XTYEo7ZvCGxXaiuTlVoxVFT6GweGlQPuOrYWtTR0OPS01lT7
+        C4YyARtlejBnTFhLp31da45aaHrFzxUGJ6fjddnPT3UaVztq4Ts9ouw/YC5N
+        +IsaJS+E3teLsnpuXN1MiTe4nE9FjVGf57Pbo7oRrkmv2lqkjrN6X9NqfGAg
+        u+2qlCz1+5jaWf299I5kXlJ5vERlb6TIV9Hj66jxOi2+ktp65qzf+iiFBe7d
+        45yA8dTW+4iFx/EaiHRISU+J3TxNN1tq1TNc6LS6RDKLsUXC0PmRp3WIszAM
+        F20R4iFUdE3ch0b2jzC02Y3NeUhsKXRNBqRQ0u7x4biAz8EL2kegGls2Ck7U
+        a7S/vWUp4mpQ8029YCboONo37fS0kuL/Coisig2KBMfNgOSGvMhpwpbAomS5
+        2vBtsoqidZDgOYg434ZukVw17btBQ0lxQB7ls1TfpZuqBugU9kBzu8fQYNAZ
+        YcO32kbYQaM59sJKYy1xTHdVjh00um0iGU2V4xZB80F5hPXh06NW+UinAzoF
+        YUzl1vOGyudB6wQ973i1JU5O3c4d3T0VDjlUvGI1943S2GPdNpssOETcmwm1
+        7Wcyx6MVBcyw5cKEBAsSxA/h6n0wf79YPNUuWoPWQ1Xyt3kYDFoPWphnghgd
+        Msazr3dfk2DxFK+fPt8N9FlXmQlT80qJDzyAK3SLtK888dd+g/R7GJfThf8c
+        fgAAAP//AwBdg0CpdgwAAA==
+    http_version: 
+  recorded_at: Wed, 04 May 2016 18:03:55 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/fraudulent_purchase/fails.yml
+++ b/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/fraudulent_purchase/fails.yml
@@ -1,0 +1,105 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <first-name>Card</first-name>
+          <last-name>Holder</last-name>
+          <email>mohamed_moore@mayert.us</email>
+          <credit-card>
+            <cardholder-name>Card Holder</cardholder-name>
+            <billing-address>
+              <first-name>John</first-name>
+              <last-name>Doe</last-name>
+              <street-address>10 Lovely Street</street-address>
+              <extended-address>Northwest</extended-address>
+              <locality>Herndon</locality>
+              <region>AL</region>
+              <country-code-alpha2>US</country-code-alpha2>
+              <postal-code>66086-5882</postal-code>
+            </billing-address>
+            <payment-method-nonce>fake-gateway-rejected-fraud-nonce</payment-method-nonce>
+            <options>
+              <verify-card type="boolean">true</verify-card>
+            </options>
+          </credit-card>
+          <device-data nil="true"/>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.60.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Date:
+      - Wed, 04 May 2016 23:13:23 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 059ed4fc-ee3b-4088-94a8-9a6ec84044c7
+      X-Runtime:
+      - '0.252607'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIABOCKlcAA5xWS3PbNhC++1dwdGoPCEm9rHpoJpl20kwn00MT99BLZkWs
+        RMQkwACgHPbXdwk+JVKNnRvx7bfYxT4Zvf6WZ94JtRFK3i/CV8HCQ5koLuTx
+        fvHw6R3bLV7HNxEUgqHWSjONplDSYHzjeZGDTP3ZHzxbFXi/AK2hWviO5Q+0
+        qAANeaeRlMaqHHVzJOAgtLFMQo7xr6B55I+AjpNBh7xXGUcd+QPScTAHkcW5
+        Sgnkn3OlNL7JoUJtX5WG/HHijpxo5MKyhAx2WI3SMXUGBn+8zuKlcFDbiyyj
+        2DHgnCJlBsn56/5QqZx73cULf1M48zxHMlYj2t5OGHgf1AmzyvvoBJF/QRjr
+        4jeLkiPvhX8qbdMnNKQ2kZ15phLIhK3i96glV/SEHhnTNB6pnOK3HyK//RxL
+        E1VKqytGVYYMsiKFZfzwkYI6g4/1CmUsZE4cb7fBbss2u90y8sf4kAj/aiao
+        BqscpWU52lRxJpVMMD7AI7IjWHyCior8CyaWgnDQULYMMjSnN1yrCktPPQ8Y
+        dZY4VE1tWV3SJWNk5O1EOeJ4EgkyQ76ThAnuSZHdL+pbmr7qqsq5SF2UpEDO
+        zfMoupdVTtCo/erXdZ0Z5WQTjhj/3oTD+6sNx53njEV+R7jpnigSsH2eqTbB
+        liZuo/m5i2Zdk07Qdv/p1E8Tl72p4xGczMXc+T/mqBKexT9vke+qnFdHnRSN
+        YOjVbVSuyhv1PkWQuFKnVMWmIA/qeE5FjVKhVUK+PSMAM0xLzRw/yEepnqT3
+        08+U4yuc5gYyuvqXb/PbyO/tt100N6GvzbDvzi+aAHkBspot1B+caz80054x
+        z67PspfMo37muTA8SEHdQA+iejGeOnhvKf/UQcMIHKLVz7GuaabLKrLqEeVs
+        MPdCxusgCMKwvkeeZ2gdh5ta0B56V+lqVi/x+G9hoNl1zXkIdSG063eWK2nT
+        OFzWMb4AZ9gVgo6XwTI4ozu0t97OJFYnwo0Utxom6Njbl67pqJTia4lMlvme
+        RILTUKcRRoMQ1/tlsNvwcLVdJcntOrz9Zb8/bMPwkECy3hwi/6pqXxUaC6D2
+        aduu7rkG6AgpQmZTcg0HzgjraBz3wg6M5tgLS03ppCY+lhkV0cjaRDLquXrK
+        CMgG8gjr3YdKq2zE6YCOIIwp67W6B/k4sM7Qy6JXB1bLoV6XI9tT4RBDxcvE
+        TcFRGHusW1+TjUZI/WYGtv0L5XS0IscFVV24ZcGGBetPy9VduLpbrv5xV7QK
+        7Q1lwV92w6DQbNHzbRj5cz/O/wEAAP//AwAANc9xdQsAAA==
+    http_version: 
+  recorded_at: Wed, 04 May 2016 23:13:23 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/order_gets_updated_with_device_data/order_passes_device_data_to_create_profile.yml
+++ b/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/order_gets_updated_with_device_data/order_passes_device_data_to_create_profile.yml
@@ -1,0 +1,115 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <first-name>John</first-name>
+          <last-name>Doe</last-name>
+          <email>domenico@bernier.com</email>
+          <credit-card>
+            <cardholder-name>John Doe</cardholder-name>
+            <billing-address>
+              <first-name>John</first-name>
+              <last-name>Doe</last-name>
+              <street-address>PO Box 1337</street-address>
+              <extended-address>Northwest</extended-address>
+              <locality>Herndon</locality>
+              <region>AL</region>
+              <country-code-alpha2>US</country-code-alpha2>
+              <postal-code>47525-1563</postal-code>
+            </billing-address>
+            <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+            <options>
+              <verify-card type="boolean">true</verify-card>
+            </options>
+          </credit-card>
+          <device-data nil="true"/>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.60.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 29 Apr 2016 22:36:23 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"c85f44c108c008d1202fc2d557693dd5"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 43528971-4a29-49c4-bfd5-a5b4fe45dd01
+      X-Runtime:
+      - '0.813903'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAOfhI1cAA7RYS2/jNhC+768wfFdkyXbsBArTLIqiaLvpArvpoZcFJdIx
+        NzKpJSnH3l/fIfWiJL+THgyYM99QQ87rk6L7zSodrKlUTPC7YXA1Gg4oTwRh
+        /Plu+PT1N28+vEcfoiRXWqyoRB8Gg4gRNJ8F0+lkPI98WBgZ6JIl5tqD9c+Y
+        T7c/f9zo2evqdTMJI9/VGvSCSaU9jlcU/SGWPPIdgdGnuFr9KmjkN0ujTMQq
+        w3w74Cy9G2qZ06Fv5XSFWYoIuMlZIn6JqeSMyiuAR36hM6hsKTjt2S7wpid7
+        pbFiuo9NJMWaEg/rgd5m9G5IYKnZig5ROAquvdHEC2++huHt+Po2HP8b+Y2B
+        tc8zcp59Y1A838bCWzCaElW7RJj2EiyJKjfFUuLt0Gjb+kICspilKUTZw4RI
+        qlQlL+L7sq4iW8qqBPBawXelDfZIdEvUoRhXD90d6VKrtKRU1/5//nvwUWwG
+        wXg8i/yOrjGiG005MZdZqh6F1MtXqjQkSVfnOCsSnDK9Rb9DVhEBZ6olDUjS
+        Z6gi9PBX5Jd/G10mlMapB5VF0WQ2DadeML0eR74rdw+ecy23VuzhNFviED19
+        gfveIT9kNQarh11m431mPIdwsgTNJ6OOXaXpG9qoPXGoFTL4oiFV1UAsBg8W
+        jptdusF9WxmVu7yxmOwe/p5SgBLhaDIKwvncYOpwRqaOPPM49A9T5oT12kUs
+        RUqgNOo6GNg872pqC7EyXZLhFK7yhYtXbm6uljWw4jLFwmNK5ZgnFDVX7Epr
+        i7ff8+nV3yBNfWhTAzZve9IKT2jMdHPiYtkoFzhPK79jIVKK+RCZTmCgVtmA
+        cwkx8qDy8tT472za1VQmdJMxaf3xVoLrJQpC0wU6wh3oLcUSbi8cteBW2kJD
+        QXR8X+BU0dLK8WRJcaqXkBu0cduRVTC2ws/Uy2WKllpn6tb3sVJUq6tYYsZN
+        z3uGA77irZl6foa3MAv1txXVS0G+peJZ+GtI2KuMP99TvmZScAO4U5iTWGyg
+        5df710+EdDKlEWP+0rjWklZQ28EnKJjPg7KdT2oduCJF6qR2JagBkmYY8uhR
+        gK78X+lUHqtEssxccnu81eMg0uKFckS+T8fZdeQXq0qXc/Yjtw0stskKR2Yw
+        PSWakPFkmszoJA6CWTjGJKSLxTQmMxyPAvhBt9hnWu/9Dv1nTflKeIq87EmW
+        Wu9YSHCjKKVdA78HasR2cGKdK1ToKTHT0gpcTLJeQ8GoDPanxXT6BGXcE7om
+        eK08KqWQbczu6V3infHXf9xhQHer9sjfvdtBjLthWUaA+E4TW9zQFJXgew9T
+        M1yc2GZseqKCRKYO+XVUrmkmRQLedO8NBaPRyBTDbu2RHTSQGfSQgWZtIrwP
+        4e4Cbl3PkvUNb1O/hiq6slNpnkUep3pFzh2ie2Xmnk/5rOFltK9w/gTqZ4EH
+        6F8RpXMoYHkhbyBYDrFpV3b/XaDUHOihdSLsJERumHcPgOrZx4hTHa4zBnPf
+        5vh4rvw5j604pziL3JV2/+McqlJs/xQtEacRjRJ8iJxVkLNZV3WJJ/Hd6lxH
+        6EMJO52s1E6cyabrexYkT2wnb1xqZK0a3FNv5/HycM/7z/swELuPZOrFAw3u
+        XipBnx/hdTD49HH+5+SxOxxsmiRM2dZXzBuTKaWkdRM7nmDITZ+ltKVlQ+7d
+        ZEtgQVHZwenOjyDdt7veZ44zXnNOmH1Hp96heXfBpLtoxp0w3fbPtXMm2iWf
+        NC76oHHh54y3zNp3ecV+cxkDw21iWy8oLJsURh/+AwAA//8DAGMwtn7xFQAA
+    http_version: 
+  recorded_at: Fri, 29 Apr 2016 22:36:23 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/payment_has_associated_device_data/sends_it_to_Braintree.yml
+++ b/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/payment_has_associated_device_data/sends_it_to_Braintree.yml
@@ -1,0 +1,116 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <first-name>Card</first-name>
+          <last-name>Holder</last-name>
+          <email>carmella@sanfordpfeffer.co.uk</email>
+          <credit-card>
+            <cardholder-name>Card Holder</cardholder-name>
+            <billing-address>
+              <first-name>John</first-name>
+              <last-name>Doe</last-name>
+              <street-address>10 Lovely Street</street-address>
+              <extended-address>Northwest</extended-address>
+              <locality>Herndon</locality>
+              <region>AL</region>
+              <country-code-alpha2>US</country-code-alpha2>
+              <postal-code>21671-9798</postal-code>
+            </billing-address>
+            <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+            <options>
+              <verify-card type="boolean">true</verify-card>
+            </options>
+          </credit-card>
+          <device-data nil="true"/>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.60.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 25 Apr 2016 15:00:37 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"61828e38f3e6ec0e3f2b0851143011ef"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 72f44c6f-2976-4d40-92a9-228aae1a6eb3
+      X-Runtime:
+      - '0.888998'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIABUxHlcAA7RY247bNhB9z1cYftdK8mXtDbRKFw2KoEiDFkmKIC8BJY5t
+        ZSVSISmvna/vkLpRku21vemDAXPmDDXk3I4UvNll6WgLQiac3Y/9G288AhZz
+        mrD1/fjzpz+c5fhN+CqIC6l4BiJ8NRoFCQ2nd3fzpT/1AhcXWoa6eEOYcnD9
+        M2Lz/c8fd2rxlD3tZpPAtbUavUqEVA4jGYS/E0ED1xJofUrq1TueUhCB20q0
+        PuZZTth+xJL0fqxEAWPXyCEjSRrGRGSQpuQ3SdiKC5qvYLUCcRPzm+IxcEuQ
+        hucbzmCwyYrsBrIniGSihthYAFFAHaJGap/D/ZjiUiUZjMOJ59863syZzD/5
+        89ee93q6+Bq4rYGxL3J6mX1rUD7fxMVZJZBS2bhEE+XgJVBZbUqEIPux1nb1
+        pQRlUZKmGHGHUCpAylpexlps6yhXsjoZnE4i2NIWawX2T75h/UhXqDa6bzn0
+        gl0/9HDIK61UAkA1/vve6D3fQroffTSKwO0BWkvYKWBU32il+sCF2jyBRKOB
+        zvKYxyRN1D58B4JRjgdrJC1IwBrLKnx4H7jV31aXc6lI6mCpQTjxbxe+c7e4
+        WwauLbdPXzAl9kbskDTfkEn4+SNe+gH5KaspWj0cMpseM2MFxjSJw+XM69nV
+        mqGhCd1nhgVDMQCYr3LEV6MHAyftLv0Iv6yWql1eWFFmD/dIPWCdsHDm+ZPl
+        UmOacAa6mBz9uPDfROoTNmsbsTG9rG17o7q59ZWNEc9050xIirf5yPgT05fX
+        yFpYeZ985SRSFoTFELa3bEsbi5df9fldoEXqElG6DEzqDqQ1nkKUqPbE5bJV
+        rkiR1n5HnKdA2DjUHUFDjbIFFwLD5GDxFan239q0r6lNYJcnwvjjZJypTehP
+        dCPoCQ+g90AE3t7E68CNtIPGmuj5viKphMrK8mQDJFUbzA1o3bZkNSzJyBqc
+        QqThRqlcvnZdIiUoeRMJkjDd9tZ4wCeyx/mXuTnZZ8DUtwzUhtNvKV9zd4s5
+        e5Oz9Rtg20RwpgH3ODtpxHfY+pv9mydiOunqiAh7bF3rSGuo6eSz0F8u/aqt
+        zxoduiJ4aqV2LWgAAnKCefSBo676X+tkEclYJLm+5O6Ya8ZCoPgjsPD75pZG
+        68AtV7WuYMmPwvSwyCQrHjnBKSrCGZ3O5vECZpHvLyZTQidIHuYRXZDI8/GH
+        DeOYabP3L2hBW2AZdyR9PJIsjd6yEOhGWUqHBv8A1IrNACWqkGGpB6oHphHY
+        mHi7xYKROe4P5YD6C8t4ILRNyFY6IAQXXczhKV7hrQk4fNxpQH+r7tQ/vNtJ
+        jL1hVUaI+A6xKW5sipKzo4dpWC+JTTPWPVFiIoNFiC2VbZoLHqM3/XtDYuN5
+        uhgOa5/ZQSGfCR9y1Gx1hI8h7F3Qrdv8drXbdClgSxlt2bl0zyCfp3xlzp2i
+        fVXmXkn9jPV19K88wRkU0ABP0MAyVJdQwepWXkC0LILTLe/hi0GlOdFIm2w4
+        SIzsWB+eAvWznyNQTbgumM5Dm+dndO3PZZTFOsWlJK8y/R/nUZ1lx6dphTiP
+        cFTgUySthlzMvup7PIv31ud6hkZUsPNJS+PEhay6uWdOi9h09NalVtYpwyMl
+        dxk/vz3yKvRrmIjZRyTy0UEN6V8qDf/+8G7uffn65Z+7t1/6Q8KkSZxI0/3K
+        uaMzpZJ0buLAEzTJGbKVrrTqyYOb7AgMKKiaOBz8KNJ/0Rt89rjgdeeMGfjs
+        9Ds1966deFfNujOm3PH5dslku+YTx1UfOK78vPGSmftL3rdfXMtId9vYNgvA
+        ZZvH4av/AAAA//8DAO/QERUSFgAA
+    http_version: 
+  recorded_at: Mon, 25 Apr 2016 15:00:37 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/unsuccessful_card_verification/fails.yml
+++ b/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/unsuccessful_card_verification/fails.yml
@@ -1,0 +1,106 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ym9djwqpkxbv3xzt:4ghghkyp2yy6yqc8@api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <first-name>Card</first-name>
+          <last-name>Holder</last-name>
+          <email>alfredo@carroll.com</email>
+          <credit-card>
+            <cardholder-name>Card Holder</cardholder-name>
+            <billing-address>
+              <first-name>John</first-name>
+              <last-name>Doe</last-name>
+              <street-address>10 Lovely Street</street-address>
+              <extended-address>Northwest</extended-address>
+              <locality>Herndon</locality>
+              <region>AL</region>
+              <country-code-alpha2>US</country-code-alpha2>
+              <postal-code>31456</postal-code>
+            </billing-address>
+            <payment-method-nonce>fake-processor-declined-visa-nonce</payment-method-nonce>
+            <options>
+              <verify-card type="boolean">true</verify-card>
+            </options>
+          </credit-card>
+          <device-data nil="true"/>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.60.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Date:
+      - Wed, 04 May 2016 23:01:13 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 259c91af-a8c8-408d-b7a8-5c1e74982de7
+      X-Runtime:
+      - '1.130491'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIADl/KlcAA5xWbW/bNhD+nl8h+DtrSXGctFDUFS22YOuCAm06YF8Gmjzb
+        nCVSIymn+vc7Ui+ULbnL+k28e+54rw+Vvf1WFtERtBFK3i+SV/EiAskUF3J3
+        v3j68jO5W7zNrzJaCQJaK000mEpJA/lVFGVeZNzncIhsU8H9gmpNm8XSo5YB
+        llVU07K3YLWxqgTdHlGwFdpYImkJ+XuqebYcCXpMQXvJgyo46GwZJD0GSiqK
+        nBZbDVz9xDAYVRSvmCoxFq/qgQwBwhJE8F7mpHjce+chlqi/7VwZzDaiKLBu
+        hHKOVTJBc5rZr2ov5zI7y+6DgpnUPMhYDWCHe5I4+qiOUDTRZ6/IlmeAsS18
+        syA58EH5qLTdP4NBs4nuJDLFaCFskz+AllxhCoNkDNOww1HK333Mlt3nWMtU
+        La1uCE4YEFpUe5rmT5+xqDPysV2ljKWFV+fXyepmnS3HotCD5cUm4Og1JUhL
+        SrB7xYlUkkG+pQcglVYMsTjdHBhaYwWOwtAWgjfNGQa/qrKY5mmxcKPEtmnn
+        yuoanYwlo3AnxhmHo2BADAaEGiJ4JEVxv3Be2n3qJ0rTmmNMmu0pBjePw8qe
+        TziKRmvnsus3MivxTrpzoxc9KosTLxUOfC+96vMSjNqhsTiM1NYmH2r4V19D
+        N4Ze1S378TiQR9u13zGUibAF06M54xuvnabokaNRmF7xfUBwcroz836+i2ld
+        7aiFZ9qg7m9grkz4RY2SM6EPvaPMzz/2MDcV3uBqPlW1RmFWT29P4zjGZl7Q
+        XrS1uPNn/b6Ean1gIK93/O75NlsOMXU7N0fjl8juP4kOqaKsqGxmp/oHCfCH
+        yO8FxHeZ9F5IXAMv+go8SWGBYy44SiZS2+gdjgMuXaDJUKiB8Potmz5omVUH
+        mJk/3ziZr3BwksT5kafNWeVJktx0rVmFUNE1cY98/hU5sn0P23OociW0pwhS
+        Kmn3eZK68p4JZ9ANUI2DnMYncC8dbu+4i7geeBbyz8dEOo72/z7lWS3FPzUQ
+        WZcbVAmO5I+sh4TJ6ZrdAkvXt3cbvl3fpenreI3nOOV8m6yQ8i6aDgOhoaK4
+        OU/yINWzdOvWCnrAHmhh9xgaBMxI1sM4bIQNiPY4KGuN7cT93dUFDtHotolm
+        tG6OdAQtAngkG8KnjfuXGoXfCXqAMKZ27++GykNAnUjPh15tidNT96yO7p4q
+        Qw0Vr5knxVEZB1n/zE1ePpS4nAm13V8qx6MVJSxw6pI1iW9IvPqSXr+JkzdJ
+        +qd30Rl0HuqKv9zDNXoIBp0HLcyBoIyGivH80+OnD/H1H799fXj/S+BV32Um
+        jKeWChM8gmt0J+myPPHX/WYMDzS+WjM/7v8CAAD//wMANaxU+fULAAA=
+    http_version: 
+  recorded_at: Wed, 04 May 2016 23:01:12 GMT
+recorded_with: VCR 3.0.1

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -13,7 +13,9 @@ describe "Braintree checkout", :vcr, :js, type: :feature do
   end
 
   it "Accepts a CC payment" do
-    visit "/products/#{product.slug}"
+    using_wait_time(5) do
+      visit "/products/#{product.slug}"
+    end
     click_on 'Add To Cart'
     click_on 'Checkout'
 
@@ -51,6 +53,34 @@ describe "Braintree checkout", :vcr, :js, type: :feature do
     expect(card.cc_type).to eq("visa")
     expect(card.gateway_customer_profile_id).to be_present
     expect(card.gateway_payment_profile_id).to be_present
+  end
+
+  it "denies a fraudulent card" do
+    using_wait_time(5) do
+      visit "/products/#{product.slug}"
+    end
+    click_on 'Add To Cart'
+    click_on 'Checkout'
+
+    fill_in_address
+    click_on 'Save and Continue'
+    click_on 'Save and Continue'
+
+    # Payment
+    expect(page).to have_content(gateway.name)
+
+    braintree_fill_in 'Card Number', with: '4000111111111511'
+    braintree_fill_in 'Expiration', with: "12/20"
+    braintree_fill_in 'Card Code', with: '123'
+
+    click_on 'Save and Continue'
+    expect(page).to have_content('Gateway Rejected: fraud')
+    expect(page).to_not have_content('Place Order')
+
+    # Assert the payment details were not stored
+    order = Spree::Order.first
+    expect(order.state).to eq("payment")
+    expect(order.payments.count).to be(0)
   end
 
   def fill_in_address

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -74,7 +74,7 @@ describe "Braintree checkout", :vcr, :js, type: :feature do
     braintree_fill_in 'Card Code', with: '123'
 
     click_on 'Save and Continue'
-    expect(page).to have_content('Do Not Honor')
+    expect(page).to have_content('Do Not Honor', wait: 30)
     expect(page).to_not have_content('Place Order')
 
     # Assert the payment details were not stored

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -12,7 +12,7 @@ describe "Braintree checkout", :vcr, :js, type: :feature do
     create(:free_shipping_method)
   end
 
-  it "Accepts a CC payment" do
+  it "accepts a CC payment" do
     using_wait_time(5) do
       visit "/products/#{product.slug}"
     end
@@ -45,6 +45,77 @@ describe "Braintree checkout", :vcr, :js, type: :feature do
     expect(payment).to be_pending
     expect(payment.response_code).to be_present
 
+    card = payment.source
+    expect(card).to be_a(Spree::CreditCard)
+    expect(card.year).to eq("2020")
+    expect(card.month).to eq("12")
+    expect(card.last_digits).to eq("1111")
+    expect(card.cc_type).to eq("visa")
+    expect(card.gateway_customer_profile_id).to be_present
+    expect(card.gateway_payment_profile_id).to be_present
+  end
+
+  it "unsuccessful credit card verification" do
+    using_wait_time(5) do
+      visit "/products/#{product.slug}"
+    end
+    click_on 'Add To Cart'
+    click_on 'Checkout'
+
+    fill_in_address
+    click_on 'Save and Continue'
+    click_on 'Save and Continue'
+
+    # Payment
+    expect(page).to have_content(gateway.name)
+
+    braintree_fill_in 'Card Number', with: '4000111111111115'
+    braintree_fill_in 'Expiration', with: "12/20"
+    braintree_fill_in 'Card Code', with: '123'
+
+    click_on 'Save and Continue'
+    expect(page).to have_content('Do Not Honor')
+    expect(page).to_not have_content('Place Order')
+
+    # Assert the payment details were not stored
+    order = Spree::Order.first
+    expect(order.state).to eq("payment")
+    expect(order.payments.count).to be(0)
+  end
+
+  it "unsuccessful credit card transaction (amount >= 2000)" do
+    product = create(:product, name: "Millenium Falcon", price: 2500.00, cost_price: 2000.00)
+    using_wait_time(5) do
+      visit "/products/#{product.slug}"
+    end
+    click_on 'Add To Cart'
+    click_on 'Checkout'
+
+    fill_in_address
+    click_on 'Save and Continue'
+    click_on 'Save and Continue'
+
+    # Payment
+    expect(page).to have_content(gateway.name)
+
+    braintree_fill_in 'Card Number', with: '4111111111111111'
+    braintree_fill_in 'Expiration', with: "12/20"
+    braintree_fill_in 'Card Code', with: '123'
+
+    click_on 'Save and Continue'
+    click_on 'Place Order', wait: 30
+    expect(page).to have_content('processor_declined')
+
+    # Assert the order is not confirmed
+    order = Spree::Order.first
+    expect(order.state).to eq "payment"
+    expect(order.payments.count).to be(1)
+
+    # Assert payment failed (because of amount)
+    payment = order.payments.first
+    expect(payment).to be_failed
+
+    # Assert payment details are saved even when processor fails
     card = payment.source
     expect(card).to be_a(Spree::CreditCard)
     expect(card.year).to eq("2020")

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Spree::Order, type: :model do
+  let(:order) { Spree::Order.new}
+
+  it "has a braintree_device_data attribute" do
+    expect { order.braintree_device_data = 'abc123' }.not_to raise_error
+    expect(order.braintree_device_data).to eq("abc123")
+  end
+end

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Spree::Payment, type: :model do
+  let(:payment) { Spree::Payment.new }
   it "has a payment_method_nonce accessor" do
-    payment = Spree::Payment.new
     expect { payment.payment_method_nonce = "abc123" }.not_to raise_error
     expect(payment.payment_method_nonce).to eq("abc123")
   end

--- a/spec/models/spree/permitted_attributes_spec.rb
+++ b/spec/models/spree/permitted_attributes_spec.rb
@@ -4,4 +4,8 @@ describe Spree::PermittedAttributes do
   it "payment_attributes includes :payment_method_nonce" do
     expect(Spree::PermittedAttributes.payment_attributes).to include(:payment_method_nonce)
   end
+
+  it 'checkout_attributes includes :device_data' do
+    expect(Spree::PermittedAttributes.checkout_attributes).to include(:braintree_device_data)
+  end
 end

--- a/spec/solidus/gateway/braintree_gateway_spec.rb
+++ b/spec/solidus/gateway/braintree_gateway_spec.rb
@@ -40,6 +40,26 @@ describe Solidus::Gateway::BraintreeGateway, :vcr do
       end
     end
 
+    context 'unsuccessful card verification' do
+      let(:nonce) { Braintree::Test::Nonce::ProcessorDeclinedVisa }
+
+      it 'fails' do
+        expect{
+          payment_method.create_profile(payment)
+        }.to raise_error(Spree::Core::GatewayError, 'Do Not Honor')
+      end
+    end
+
+    context 'fraudulent purchase' do
+      let(:nonce) { Braintree::Test::Nonce::GatewayRejectedFraud }
+
+      it 'fails' do
+        expect{
+          payment_method.create_profile(payment)
+        }.to raise_error(Spree::Core::GatewayError, 'Gateway Rejected: fraud')
+      end
+    end
+
     context 'payment has associated device_data' do
       it 'sends it to Braintree' do
         payment = FactoryGirl.build(:payment,


### PR DESCRIPTION
This PR gets the device_data to enable fraud detection from Braintree. We pass the device_data
at creation of payment profile and in the confirmation of the order.

Built ontop of #29, same flow as in #28 but with better error handling for hosted fields.