### PR TITLE
Ensure device_data is added to the gateway_options hash.

### DIFF
--- a/app/models/payment_decorator.rb
+++ b/app/models/payment_decorator.rb
@@ -1,1 +1,2 @@
 Spree::Payment.include SolidusBraintree::PaymentBraintreeNonceConcern
+Spree::Payment.include SolidusBraintree::InjectDeviceDataConcern

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -1,9 +1,19 @@
 require 'spec_helper'
 
 describe Spree::Payment, type: :model do
-  let(:payment) { Spree::Payment.new }
+  let(:device_data){"{\"device_session_id\":\"75197918b634416368241bb8996b560c\",\"fraud_merchant_id\":\"600000\"}"}
+
   it "has a payment_method_nonce accessor" do
+    payment = Spree::Payment.new
+
     expect { payment.payment_method_nonce = "abc123" }.not_to raise_error
     expect(payment.payment_method_nonce).to eq("abc123")
+  end
+
+  it 'adds device_data from the associated order to gateway_options hash' do
+    payment = create(:payment)
+
+    payment.order.update_attribute(:braintree_device_data, device_data)
+    expect(payment.gateway_options[:device_data]).to be_present
   end
 end


### PR DESCRIPTION
Fix bug from PR #32 , I left out the override for gateway_options to add 
device_data to the gateway_options hash. Added test to prevent any future regression.