### PR TITLE
Ignore AVS response code in Paypal transactions.

### DIFF
--- a/app/models/solidus/gateway/braintree_gateway.rb
+++ b/app/models/solidus/gateway/braintree_gateway.rb
@@ -167,16 +167,21 @@ module Solidus
     end
 
     def build_results_hash(result)
-      if result.success?
-        {
-          authorization: result.transaction.id,
-          avs_result: {
-            code: result.transaction.avs_street_address_response_code
-          }
-        }
+      return {} unless result.success?
+
+      # We ignore avs response when doing a Paypal transaction
+      if result.transaction.paypal_details.authorization_id.present?
+        avs_code = nil
       else
-        {}
+        avs_code = result.transaction.avs_street_address_response_code
       end
+
+      {
+        authorization: result.transaction.id,
+        avs_result: {
+          code: avs_code
+        }
+      }
     end
 
     def handle_result(result)

--- a/spec/solidus/gateway/braintree_gateway_spec.rb
+++ b/spec/solidus/gateway/braintree_gateway_spec.rb
@@ -280,12 +280,12 @@ describe Solidus::Gateway::BraintreeGateway, :vcr do
       auth = payment_method.authorize(5000, card, {})
       expect(auth).to be_success
       expect(auth.authorization).to be_present
-      expect(auth.avs_result["code"]).to eq "I"
+      expect(auth.avs_result["code"]).to be_nil
 
       capture = payment_method.capture(5000, auth.authorization, {})
       expect(capture).to be_success
       expect(capture.authorization).to be_present
-      expect(capture.avs_result["code"]).to eq "I"
+      expect(capture.avs_result["code"]).to be_nil
     end
 
     it "succeeds capture on pending settlement" do


### PR DESCRIPTION
Right now Braintree return an AVS response code of "I" (i.e. "Not provided") this flags the order as
risky in the Admin UI, this PR is to ignore the avs response for all Paypal transactions.
Maybe this should only ignore "I" responses and not all avs responses
