### PR TITLE
Get client token from braintree only in the payment page.

### DIFF
--- a/lib/assets/javascripts/spree/backend/braintree/solidus_braintree.js
+++ b/lib/assets/javascripts/spree/backend/braintree/solidus_braintree.js
@@ -3,6 +3,7 @@
 Spree.routes.payment_client_token_api = Spree.pathFor("api/payment_client_token")
 
 var braintreeDropinIntegration;
+var paymentForm = "#new_payment";
 var cardSelector = "#new_payment [name=card]";
 
 var getClientToken = function(onSuccess) {
@@ -40,17 +41,19 @@ var attachDropIn = function(data) {
 };
 
 $(document).ready(function() {
-  if ($(cardSelector).length) {
-    $(cardSelector).on("change", function() {
-      if ($(cardSelector + ":checked").val() === "new") {
-        getClientToken(attachDropIn);
-      } else {
-        if (braintreeDropinIntegration) {
-          braintreeDropinIntegration.teardown();
+  if ($(paymentForm).length) {
+    if ($(cardSelector).length) {
+      $(cardSelector).on("change", function() {
+        if ($(cardSelector + ":checked").val() === "new") {
+          getClientToken(attachDropIn);
+        } else {
+          if (braintreeDropinIntegration) {
+            braintreeDropinIntegration.teardown();
+          }
         }
-      }
-    });
-  } else {
-    getClientToken(attachDropIn);
+      });
+    } else {
+      getClientToken(attachDropIn);
+    }
   }
 });


### PR DESCRIPTION
Right now we are trying to get a client token at every page load in the Admin UI, that creates
a 404 response in all pages except the payment page this manifest as an empty flash error 
in the UI, this PR makes it so that only we request the client token for Braintree only in the
payment page in the backend.