### PR TITLE
Fix braintree's initialization process from interfering with saved cards and alternate payments

### DIFF
--- a/lib/assets/javascripts/spree/frontend/braintree/solidus_braintree.js
+++ b/lib/assets/javascripts/spree/frontend/braintree/solidus_braintree.js
@@ -126,12 +126,15 @@ var getDeviceDataConfirm = function(data) {
 $(document).ready(function() {
   if ($(cardSelector).find("input[type=radio][name='order[payments_attributes][][payment_method_id]']").length) {
     $(cardSelector).find("input[type=radio][name='order[payments_attributes][][payment_method_id]']").on("change", function() {
-      paymentId = $(this).val();
-      getClientToken(initializeBraintree);
+      if ($(cardSelector + ":checked").val() === "new") {
+        paymentId = $(this).val();
+        getClientToken(initializeBraintree);
+      } else {
+        if (braintreeDropinIntegration) {
+          braintreeDropinIntegration.teardown();
+        }
+      }
     });
-    // Attempt to initialize braintree
-    paymentId = $("form input[type=radio][name='order[payments_attributes][][payment_method_id]']:checked").val();
-    getClientToken(initializeBraintree);
   }
 
   // Attempt to inject device_data to confirm form.

--- a/lib/assets/javascripts/spree/frontend/braintree/solidus_braintree.js
+++ b/lib/assets/javascripts/spree/frontend/braintree/solidus_braintree.js
@@ -127,7 +127,6 @@ $(document).ready(function() {
   if ($(cardSelector).find("input[type=radio][name='order[payments_attributes][][payment_method_id]']").length) {
     $(cardSelector).find("input[type=radio][name='order[payments_attributes][][payment_method_id]']").on("change", function() {
       if ($(cardSelector + ":checked").val() === "new") {
-        paymentId = $(this).val();
         getClientToken(initializeBraintree);
       } else {
         if (braintreeDropinIntegration) {


### PR DESCRIPTION
When using hosted fields, `initializeBraintree` loads and breaks saved payments and other custom payments by running Braintree's fields through their validation callbacks when we aren't interested in those fields. 

This only initializes Braintree when it's radio button is selected and tears its initialization down when using other payments methods. 