### PR TITLE
Change solidus dependency to components

### DIFF
--- a/solidus_braintree.gemspec
+++ b/solidus_braintree.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "solidus", [">= 1.0.0", "< 2"]
+  spec.add_dependency "solidus_api", [">= 1.0.0", "< 2"]
+  spec.add_dependency "solidus_core", [">= 1.0.0", "< 2"]
   spec.add_dependency "braintree", "~> 2.46"
 
   spec.add_development_dependency "bundler", "~> 1.10"


### PR DESCRIPTION
The gem currently depends on solidus (which is a meta gem for all
solidus modules). This means that even if the site does not use
solidus_frontend, this gem will require it to be installed.

This changes the dependency to only include solidus_core and solidus_api
which are the components this actually requires.