### PR TITLE
Add support for cancel

### DIFF
--- a/app/models/solidus/gateway/braintree_gateway.rb
+++ b/app/models/solidus/gateway/braintree_gateway.rb
@@ -165,6 +165,16 @@ module Solidus
       '123'
     end
 
+    def cancel(response)
+      if voidable?(response)
+        void(response)
+      else
+        handle_result(
+          braintree_gateway.transaction.refund(response)
+        )
+      end
+    end
+
     private
     def message_from_result(result)
       if result.success?


### PR DESCRIPTION
Spree::PaymentMethod expects payment methods (like BraintreeGateway) to
implement the cancel method.

See https://github.com/solidusio/solidus/blob/f05481bb50c04b03f76599ab333ab6c7419123b2/core/app/models/spree/payment_method.rb#L75-L77

This implements the cancel method to either
void or refund the payment depending upon what is appropriate.