### PR TITLE
Add config to disable address verification

### DIFF
--- a/app/models/solidus/gateway/braintree_gateway.rb
+++ b/app/models/solidus/gateway/braintree_gateway.rb
@@ -7,6 +7,7 @@ module Solidus
     preference :public_key, :string
     preference :private_key, :string
     preference :always_send_bill_address, :boolean, default: false
+    preference :verify_address, :boolean, default: true
 
     CARD_TYPE_MAPPING = {
       'American Express' => 'american_express',
@@ -62,7 +63,6 @@ module Solidus
         email: email,
         credit_card: {
           cardholder_name: source.name,
-          billing_address: map_address(address),
           payment_method_nonce: payment.payment_method_nonce,
           options: {
             verify_card: true,
@@ -70,6 +70,7 @@ module Solidus
         },
         device_data: payment.order.braintree_device_data
       }
+      params[:credit_card][:billing_address] = map_address(address) if preferred_verify_address
 
       result = braintree_gateway.customer.create(params)
 
@@ -254,7 +255,9 @@ module Solidus
       params[:options] ||= {}
       params[:amount] = amount(cents)
       params[:channel] ||= "Solidus"
-      params[:shipping] = map_address(options[:shipping_address]) if options[:shipping_address]
+      params[:shipping] = map_address(options[:shipping_address]) if (
+        options[:shipping_address] && preferred_verify_address
+      )
 
       if options[:payment_method_nonce]
         params[:payment_method_nonce] = options[:payment_method_nonce]
@@ -264,8 +267,10 @@ module Solidus
 
       # Send the bill address if we're using a nonce (i.e. doing a one-time
       # payment) or if we're configured to always send the bill address
-      if options[:payment_method_nonce] || preferred_always_send_bill_address
-        params[:billing] = map_address(options[:billing_address]) if options[:billing_address]
+      if (
+          options[:payment_method_nonce] || preferred_always_send_bill_address
+        ) && options[:billing_address] && preferred_verify_address
+        params[:billing] = map_address(options[:billing_address])
       end
 
       # if has profile, set the customer_id to the profile_id and delete the customer key

--- a/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/payment_has_associated_device_data/when_verify_address_is_false/sends_it_to_Braintree.yml
+++ b/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/payment_has_associated_device_data/when_verify_address_is_false/sends_it_to_Braintree.yml
@@ -1,0 +1,106 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <first-name>Card</first-name>
+          <last-name>Holder</last-name>
+          <email>adaline@hegmann.us</email>
+          <credit-card>
+            <cardholder-name>Card Holder</cardholder-name>
+            <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+            <options>
+              <verify-card type="boolean">true</verify-card>
+            </options>
+          </credit-card>
+          <device-data>{"device_session_id":"75197918b634416368241bb8996b560c","fraud_merchant_id":"600000"}</device-data>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.63.0
+      X-Apiversion:
+      - '4'
+      Authorization:
+      - Basic eW05ZGp3cXBreGJ2M3h6dDo0Z2hnaGt5cDJ5eTZ5cWM4
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 06 Jul 2016 19:47:46 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"d74535890ed09a0ca19f92d5b8526721"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 20f66a4c-9ea6-42cd-bfb1-4c7fc5c6811b
+      X-Runtime:
+      - '0.719300'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAGJgfVcAA7RY227jNhB9z1cYflck2Y7tBIrSokWvaLFANy3QlwUljW0m
+        EqklKcfer+9QV8qyZBlJHwKEM2fI4XAux/KeDkk82YOQlLPHqXvrTCfAQh5R
+        tn2cPn/+yVpPn/wbL8yk4gkI/2Yy8Wjkz53FfD5bOJ6NCy1DXbgjTFm4/haw
+        u+O3r/dq9Za8HRYzzza1Gr2hQiqLkQT8H4iIPNsQaH1MqtUvPI5AeHYj0fqQ
+        Jylhxwmj8eNUiQymdi6HhNDYJxGJKYPvdrBNCGO3mfTsQqMx6Y4z6FhuyKEj
+        e4NAUtXFhgKIgsgiaqKOKTxOI1wqmsDUnznu0nJWlrP87N4/LFYPi+W/nt0Y
+        5PZZGl1n3xgU5+ePYW0oxJGsXYqoskIMpiw3JUKQ41Rr2/pCgrKAxhimrUWi
+        SICUlbx44O1L9bSlrMoAq/X6prTBNq95GrsSUL9mj77nfUutVAJAVX73gOCg
+        gEU6aIOwmIeYLKrvKAFbLIweZcqlIrGF1QL+/cJ1Vp5tiszrZEyJYy62SJzu
+        yKz34qfI+Rgky/ANaHgBOhTw96V0ucs7Ezvfw+5JS0xX5i8cd7Zeawyr5Tqn
+        LX2c/zeVBD2r1yZil/eRpuVMqsZyqqyNeKK7FiWx/8xeGX9jiG1kDayILd9Y
+        VMqMsBB8DexKa4v3h3p8MTZInegKc9l//stA1tIKH0FAVXPjYtkoNySLK78D
+        zmMgbOrrbNLQXNmAM4HPZGEFZbH239j0VFOZwCGlIvfHSjhTO9/F2dERnkEf
+        gQiM3sxpwXNpCw3Rqe8bEksorQxPdkBitcPcgMZtQ1bBaEK2YGUi9ndKpfLB
+        tomUoORtIAhluk1t8YJv5HiLqWOn5JgAU18SUDsefYn5ltt7zNnblG2fgO2p
+        4EwDHiVhUcAP2IHr/esTMZ10dQSEvTautaQVNG+yC99dr91yfi5qHboieGyk
+        diWoAQJSgnn0J0dd+X+lk1kgQ0FTHeT2tKlbiqf4KzB/yZYhwzcsVpUuY/Rr
+        ljetIE9WvDLFYSb8RTRf3IUrWASuu5rNSTSDzeYuiFYkcFz8w4bRZ1rv/QEt
+        aA8s4ZaMXnuSpdYbFgLdKErp3PztgBpxPs+IyqRf6AHZUCkwMeF+jwUjU9wf
+        ivHyB5ZxR2iakL20QAgu2pjzE6DEG/Ore9ww4HSr9pQ+Af9a7DaIMTcsywgR
+        LxDmxY1NUfZNZpOPkjBvxronSkxkMMiooTJNU8FD9OY0br7rOI4uhvPaCzso
+        5CP+9ylq9vqF+xDmLujWLp2/rMU6aHOxhruZshG8Kwdd4F5Ftg3xrzJnL3Ow
+        HDiOhxWeDXKxHDLEx4rQj+Rk5TUvESODkLTLscunS81A46vf7iyRMZ/nfNeu
+        zr5EeOrIXzFNuzaXZ2rlz3UUw7jFtaSsNP0f50eVRf3Tr0SMIwgleIhUVZCr
+        2VIVx1E8tbrXhbFfwsaTjNqJK1lwHWceZWHegRuXGlmrDHtK7jo+fdfz0+Vj
+        mEO+j6Dy1UINOQ1q5H/6+bcfnbvlP6v1p99PW3qeJiHV32GqOaEzpZS0InHm
+        BE1KuuyiLS0JRSeSLUEO8speDWe/JZz+MOt8Lbji58nwxBqeVUNTasR8GjWZ
+        BmfSwDQaOYfGfhkY+11g9FeBi6PvQ36mvrukkCU2yVYvAJdNOvk3/wEAAP//
+        AwACVvnPxRQAAA==
+    http_version: 
+  recorded_at: Wed, 06 Jul 2016 19:47:46 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/payment_has_associated_device_data/when_verify_address_is_true/sends_it_to_Braintree.yml
+++ b/spec/cassettes/Solidus_Gateway_BraintreeGateway/a_customer_profile/payment_has_associated_device_data/when_verify_address_is_true/sends_it_to_Braintree.yml
@@ -1,0 +1,118 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <first-name>Card</first-name>
+          <last-name>Holder</last-name>
+          <email>abdullah_kirlin@runolfsdottirframi.info</email>
+          <credit-card>
+            <cardholder-name>Card Holder</cardholder-name>
+            <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+            <options>
+              <verify-card type="boolean">true</verify-card>
+            </options>
+            <billing-address>
+              <first-name>John</first-name>
+              <last-name>Doe</last-name>
+              <street-address>10 Lovely Street</street-address>
+              <extended-address>Northwest</extended-address>
+              <locality>Herndon</locality>
+              <region>AL</region>
+              <country-code-alpha2>US</country-code-alpha2>
+              <postal-code>63573</postal-code>
+            </billing-address>
+          </credit-card>
+          <device-data>{"device_session_id":"75197918b634416368241bb8996b560c","fraud_merchant_id":"600000"}</device-data>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.63.0
+      X-Apiversion:
+      - '4'
+      Authorization:
+      - Basic eW05ZGp3cXBreGJ2M3h6dDo0Z2hnaGt5cDJ5eTZ5cWM4
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 06 Jul 2016 19:47:45 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - s8282g6qcjgm2dfk
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"b6dfc0fc9c6d697d78217328970dde2f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 7cf9907e-4dd3-48d4-8879-efc811551463
+      X-Runtime:
+      - '0.693589'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAGFgfVcAA7RYWW/jNhB+z68w/K5I8hEngaI06KJdLHYXxe6mLfoSUCJt
+        s5FILUn5yK/vkLooyXZsJ30wYM58MxrOLQX3mzQZrIiQlLO7oX/pDQeExRxT
+        trgbPv74zbke3ocXQZxLxVMiwovBIKA4HPn+jed708CFg6YBL14iphw4v0Rs
+        un35eaNm63S9mYwC1+Zq9JwKqRyGUhL+igQOXIug+QmqTh95gokI3Iai+TFP
+        M8S2A0aTu6ESORm6hk5SRJMQRThPErR8eqYioewXkTOezCXmSlExFyill5TN
+        eeAWcC2YLTkjPXVztOnR1iSSVPWxsSBIEewgNVDbjNwNMRwVTckwHHn+lePN
+        HO/qh39zO5ndTqb/BG4jYOTzDJ8m3wgUzzcRcuaUJFjWJmGqnBg8LEulSAi0
+        HWpum19QgBbRBFy2cBDGgkhZ0YuojzdVvEtalRZOKyVsaoO1QvyJL1k35iWq
+        ifMHTjphrx66O/glVypBiKrt973BZ74iyXbw3TACtwNoJMlGEYa1R0vWVy7U
+        ck0kCPV4lsU8RglV2/AjEQxzuFhNaUCCLKDAwofPgVv+bXgZlwolDhQdCa/G
+        09k4cG2SffGcKbE1ZAcl2RKNwsfv4O8d9ENSY5B62CU23ifGcggnjcPrideR
+        qzh9QRO1Rwa1gsH3kKpywOeDBwNHjZZucN9WRqWWNxaT0eHuKQUoERZOPH90
+        fa0xdSQDXUeOflz4J5X6hvXZRixNQ2t636DqcF1mLcRT3T4pSsCbz4yvmXZe
+        TWtghT/53KFS5ojFJGy8bFNribe7+vgG0CB1dShdASZ1e9QKj0lEVXPj4tgw
+        5yhPKrsjzhOC2DDUzUBDDbMB5wLC5EDd5Ym231La5VQiZJNRYexxUs7UMvRH
+        ugd0iDvQW4IEeG/kteCG2kJDTXRsn6NEklLKsmRJUKKWkBukMduiVTCaogVx
+        cpGES6Uyeeu6SEqi5GUkEGW64y3ggmu0vYTUcTO0TQlTTylRS46fEr7g7gpy
+        9jJji3vCVlRwpgF3EjEccd31a/31EyGddHVEiD03prWoFdQ08UnoX1/7ZUef
+        1DwwRfDESu2KUAMEyRDk0VeY19X/iifzSMaCZtrJ7QlXT4RA8WfCwsX4Zr1e
+        BG5xqng5oz9z08Mik6xwZQoDVIQTPJ5M4xmZRL4/G40RHpH5fBrhGYo8H37Q
+        MPaJ1rrfoQWtCEu5I/HznmSp+ZaEADOKUto183ughmxmJ1K5DAs+wXpWGoKN
+        iVcrKBiZgX5SDKgvUMY9oi2CVtIhQnDRxuwe4CXemoD9xx0GdFW1B/5ubQcx
+        tsKyjADxL4lNcUNTlJztvUy9+qLYNGPdEyUkMrG2Yotli2aCx2BN12+w03ie
+        Lobd3Fc0KFhlwocMOCsd4X0IWwuYhdnLauNNF+39r9kXbdqxu55Bvr7vFVl3
+        aOcrc/fMvc9In7f7FTc4Yv8zwAM7YBGsI/fA0iFv2LKs7aZd2/0XgpJzoIvW
+        ibBzK7LDvHsEVM9+bXuqI3XCaO7LvD6gK3tO21esW5y64ZWi/+MwqhJs/ygt
+        EcdtGyX40IZWQU5evSo/HrX0Vvd6ZYcoYcdvLLURJ67UtZ85zmPTzhuTGlqr
+        DPeU3GnL+WTPe9D7rCFGj6Dy2QEO6joVh3/8/umD9/e3v759Gfvd+WDSJKbS
+        NL5i6OhMKSktT+x4gt5w+qtKm1q2454nWwQDCsr+TXZ+DOm+5fU+d5zwrnPE
+        +Ht18B0aeecOu7PG3BEDbv9oO3KonfNp46wPG2d+1njLuH2X9+w3lzGsuU1Y
+        6wOBY5PC4cV/AAAA//8DAJS4xZIPFgAA
+    http_version: 
+  recorded_at: Wed, 06 Jul 2016 19:47:45 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Braintree supports address verification if an address is present,
however, this can sometimes lead to addresses being declined because
they don't match the address on file with the PayPal account or credit
card.

As some people may wish to disable this, I have added this configuration
to be able to disable sending the adderss to Braintree.