### PR TITLE
Add --ssl-protocol=any to phantomjs_options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,18 @@
 sudo: false
 language: ruby
+cache:
+  directories:
+    - "travis_phantomjs"
+
+before_install:
+  - "phantomjs --version"
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
+  - "phantomjs --version"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
+  - "phantomjs --version"
+
 rvm:
   - 2.3.1
 env:

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -65,9 +65,9 @@ describe "Braintree checkout", :vcr, :js, type: :feature do
     # Payment
     expect(page).to have_content(gateway.name)
 
-    click_on 'braintree-paypal-button'
-
-    paypal_popup = page.driver.window_handles.last
+    paypal_popup = window_opened_by do
+      click_on 'braintree-paypal-button'
+    end
 
     within_window(paypal_popup) do
       expect(page).to have_content('Proceed with Sandbox Purchase')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,10 @@ require 'capybara/rspec'
 require 'capybara-screenshot/rspec'
 require 'capybara/poltergeist'
 Capybara.register_driver(:poltergeist) do |app|
-  Capybara::Poltergeist::Driver.new app, timeout: 90
+  Capybara::Poltergeist::Driver.new app, {
+    phantomjs_options: %w[--ssl-protocol=any --ignore-ssl-errors=true --load-images=false],
+    timeout: 90
+  }
 end
 Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = 10


### PR DESCRIPTION
As of this afternoon the spec suite fails with SSL errors when hitting the braintree sandbox API.