### PR TITLE
Fix Travis issue with Solidus old versions (Factory Bot gem)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,10 +14,20 @@ else
   gem "rails_test_params_backport", group: :test
 end
 
-gem 'pg', '~> 0.21'
-gem 'mysql2', '~> 0.4.10'
+case ENV['DB']
+when 'mysql'
+  gem 'mysql2'
+when 'postgres'
+  gem 'pg', '< 1.0'
+end
 
 group :development, :test do
+  if branch < "v2.5"
+    gem 'factory_bot', '4.10.0'
+  else
+    gem 'factory_bot', '> 4.10.0'
+  end
+
   gem "pry-rails"
 end
 


### PR DESCRIPTION
For Solidus versions older than `v2.5` gem `factory_bot 4.10.0` must be used
for compatibility reasons.