### PR TITLE
Fix references to Spree.t

### DIFF
--- a/app/views/spree/admin/payments/source_forms/_braintree.html.erb
+++ b/app/views/spree/admin/payments/source_forms/_braintree.html.erb
@@ -5,7 +5,7 @@
         <label><%= radio_button_tag :card, card.id, card == previous_cards.first %> <%= card.display_number %><br /></label>
       <% end %>
     <% end %>
-    <label><%= radio_button_tag :card, 'new', false, { id: "card_new#{payment_method.id}" } %> <%= Spree.t(:use_new_cc) %></label>
+    <label><%= radio_button_tag :card, 'new', false, { id: "card_new#{payment_method.id}" } %> <%= t('spree.use_new_cc') %></label>
   </div>
 
   <div id="card_form<%= payment_method.id %>" data-hook>
@@ -27,7 +27,7 @@
 
     <div class="clear"></div>
 
-    <%= label_tag "card_address#{payment_method.id}", Spree.t(:billing_address) %>
+    <%= label_tag "card_address#{payment_method.id}", t('spree.billing_address') %>
     <% address = @order.bill_address || @order.ship_address || Spree::Address.build_default %>
     <%= fields_for "#{param_prefix}[address_attributes]", address do |f| %>
       <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => f, :type => "billing" } %>

--- a/app/views/spree/admin/payments/source_views/_braintree.html.erb
+++ b/app/views/spree/admin/payments/source_views/_braintree.html.erb
@@ -4,13 +4,13 @@
   <div class="row">
     <div class="alpha six columns">
       <dl>
-        <dt><%= Spree.t(:identifier) %>:</dt>
+        <dt><%= t('spree.identifier') %>:</dt>
         <dd><%= payment.number %></dd>
 
-        <dt><%= Spree.t(:response_code) %>:</dt>
+        <dt><%= t('spree.response_code') %>:</dt>
         <dd><%= braintree_transaction_link(payment.response_code) %></dd>
 
-        <dt><%= Spree.t(:name_on_card) %>:</dt>
+        <dt><%= t('spree.name_on_card') %>:</dt>
         <dd><%= payment.source.name %></dd>
 
         <dt><%= Spree::CreditCard.human_attribute_name(:cc_type) %>:</dt>

--- a/app/views/spree/checkout/payment/_braintree.html.erb
+++ b/app/views/spree/checkout/payment/_braintree.html.erb
@@ -7,7 +7,7 @@
     </div>
     <div id="#braintree_paypal_container"></div>
   </div>
-  
+
   <div class="braintree-cc-input">
     <div class="braintree-cc-header">
       <%= t('solidus_braintree.creditcard_header_html') %>
@@ -16,31 +16,31 @@
     <% param_prefix = "payment_source[#{payment_method.id}]" %>
 
     <p class="field">
-      <%= label_tag "name_on_card_#{payment_method.id}", Spree.t(:name_on_card) %><span class="required">*</span><br />
+      <%= label_tag "name_on_card_#{payment_method.id}", t('spree.name_on_card') %><span class="required">*</span><br />
       <%= text_field_tag "#{param_prefix}[name]", "#{@order.billing_firstname} #{@order.billing_lastname}", { id: "name_on_card_#{payment_method.id}", :autocomplete => "cc-name" } %>
     </p>
 
     <p class="field" data-hook="card_number">
-      <%= label_tag "braintree_card_number", Spree.t(:card_number) %><span class="required">*</span><br />
+      <%= label_tag "braintree_card_number", t('spree.card_number') %><span class="required">*</span><br />
       <label for="braintree_card_number" id="braintree_card_number" class="braintree-hosted-field"></label>
       &nbsp;
       <span id="card_type" style="display:none;">
-        ( <span id="looks_like" ><%= Spree.t(:card_type_is) %> <span id="type"></span></span>
-        <span id="unrecognized"><%= Spree.t(:unrecognized_card_type) %></span>
+        ( <span id="looks_like" ><%= t('spree.card_type_is') %> <span id="type"></span></span>
+        <span id="unrecognized"><%= t('spree.unrecognized_card_type') %></span>
         )
       </span>
     </p>
 
     <p class="field" data-hook="card_expiration">
-      <%= label_tag "braintree_card_expiry", Spree.t(:expiration) %><span class="required">*</span><br />
+      <%= label_tag "braintree_card_expiry", t('spree.expiration') %><span class="required">*</span><br />
       <label for="braintree_card_expiry" id="braintree_card_expiry" class="braintree-hosted-field"></label>
     </p>
 
     <p class="field" data-hook="card_code">
-      <%= label_tag "braintree_card_code", Spree.t(:card_code) %><span class="required">*</span><br />
+      <%= label_tag "braintree_card_code", t('spree.card_code') %><span class="required">*</span><br />
 
       <label for="braintree_card_code" id="braintree_card_code" class="braintree-hosted-field card-code"></label>
-      <%= link_to "(#{Spree.t(:what_is_this)})", spree.cvv_path, :target => '_blank', "data-hook" => "cvv_link", :id => "cvv_link" %>
+      <%= link_to "(#{t('spree.what_is_this')})", spree.cvv_path, :target => '_blank', "data-hook" => "cvv_link", :id => "cvv_link" %>
     </p>
   </div>
 


### PR DESCRIPTION
`Spree.t` is deprecated and should be replaced with
`I18n.t('spree.XXXXX')`.

Closes https://github.com/solidusio/solidus_braintree/issues/76