### PR TITLE
Update how braintree client tokens are generated (Implementation 2)

### DIFF
--- a/app/helpers/braintree_view_helpers.rb
+++ b/app/helpers/braintree_view_helpers.rb
@@ -17,4 +17,28 @@ module BraintreeViewHelpers
       payment_id
     end
   end
+
+  ##
+  # Generate a client token for a user
+  # @return [String, NilClass]
+  #
+  def braintree_client_token_for(user = nil)
+    options = {}
+    options[:customer_id] = user.braintree_customer_id if user.present?
+
+    braintree_gateway.generate_client_token(options)
+  rescue => error
+    Rails.logger.error(error)
+    nil
+  end
+
+  private
+
+  def braintree_gateway
+    @gateway ||= if params[:payment_method_id]
+      Solidus::Gateway::BraintreeGateway.find_by!(id: params[:payment_method_id])
+    else
+      Solidus::Gateway::BraintreeGateway.find_by!(active: true)
+    end
+  end
 end

--- a/app/views/spree/admin/payments/source_forms/_braintree.html.erb
+++ b/app/views/spree/admin/payments/source_forms/_braintree.html.erb
@@ -5,7 +5,7 @@
         <label><%= radio_button_tag :card, card.id, card == previous_cards.first %> <%= card.display_number %><br /></label>
       <% end %>
     <% end %>
-    <label><%= radio_button_tag :card, 'new', false, { id: "card_new#{payment_method.id}" } %> <%= Spree.t(:use_new_cc) %></label>
+    <label><%= radio_button_tag :card, 'new', false, { id: "card_new#{payment_method.id}" } %> <%= I18n.t('spree.use_new_cc') %></label>
   </div>
 
   <div id="card_form<%= payment_method.id %>" data-hook>
@@ -24,10 +24,11 @@
 
     <div id="braintree-dropin"></div>
     <input type="hidden" id="payment_method_nonce" name="payment[payment_method_nonce]">
+    <%= hidden_field_tag "braintree_client_token", braintree_client_token_for(@order.user) %>
 
     <div class="clear"></div>
 
-    <%= label_tag "card_address#{payment_method.id}", Spree.t(:billing_address) %>
+    <%= label_tag "card_address#{payment_method.id}", I18n.t('spree.billing_address') %>
     <% address = @order.bill_address || @order.ship_address || Spree::Address.build_default %>
     <%= fields_for "#{param_prefix}[address_attributes]", address do |f| %>
       <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => f, :type => "billing" } %>

--- a/app/views/spree/admin/payments/source_views/_braintree.html.erb
+++ b/app/views/spree/admin/payments/source_views/_braintree.html.erb
@@ -4,13 +4,13 @@
   <div class="row">
     <div class="alpha six columns">
       <dl>
-        <dt><%= Spree.t(:identifier) %>:</dt>
+        <dt><%= I18n.t('spree.identifier') %>:</dt>
         <dd><%= payment.number %></dd>
 
-        <dt><%= Spree.t(:response_code) %>:</dt>
+        <dt><%= I18n.t('spree.response_code') %>:</dt>
         <dd><%= braintree_transaction_link(payment.response_code) %></dd>
 
-        <dt><%= Spree.t(:name_on_card) %>:</dt>
+        <dt><%= I18n.t('spree.name_on_card') %>:</dt>
         <dd><%= payment.source.name %></dd>
 
         <dt><%= Spree::CreditCard.human_attribute_name(:cc_type) %>:</dt>

--- a/app/views/spree/checkout/payment/_braintree.html.erb
+++ b/app/views/spree/checkout/payment/_braintree.html.erb
@@ -7,7 +7,7 @@
     </div>
     <div id="#braintree_paypal_container"></div>
   </div>
-  
+
   <div class="braintree-cc-input">
     <div class="braintree-cc-header">
       <%= t('solidus_braintree.creditcard_header_html') %>
@@ -16,31 +16,31 @@
     <% param_prefix = "payment_source[#{payment_method.id}]" %>
 
     <p class="field">
-      <%= label_tag "name_on_card_#{payment_method.id}", Spree.t(:name_on_card) %><span class="required">*</span><br />
+      <%= label_tag "name_on_card_#{payment_method.id}", I18n.t('spree.name_on_card') %><span class="required">*</span><br />
       <%= text_field_tag "#{param_prefix}[name]", "#{@order.billing_firstname} #{@order.billing_lastname}", { id: "name_on_card_#{payment_method.id}", :autocomplete => "cc-name" } %>
     </p>
 
     <p class="field" data-hook="card_number">
-      <%= label_tag "braintree_card_number", Spree.t(:card_number) %><span class="required">*</span><br />
+      <%= label_tag "braintree_card_number", I18n.t('spree.card_number') %><span class="required">*</span><br />
       <label for="braintree_card_number" id="braintree_card_number" class="braintree-hosted-field"></label>
       &nbsp;
       <span id="card_type" style="display:none;">
-        ( <span id="looks_like" ><%= Spree.t(:card_type_is) %> <span id="type"></span></span>
-        <span id="unrecognized"><%= Spree.t(:unrecognized_card_type) %></span>
+        ( <span id="looks_like" ><%= I18n.t('spree.card_type_is') %> <span id="type"></span></span>
+        <span id="unrecognized"><%= I18n.t('spree.unrecognized_card_type') %></span>
         )
       </span>
     </p>
 
     <p class="field" data-hook="card_expiration">
-      <%= label_tag "braintree_card_expiry", Spree.t(:expiration) %><span class="required">*</span><br />
+      <%= label_tag "braintree_card_expiry", I18n.t('spree.expiration') %><span class="required">*</span><br />
       <label for="braintree_card_expiry" id="braintree_card_expiry" class="braintree-hosted-field"></label>
     </p>
 
     <p class="field" data-hook="card_code">
-      <%= label_tag "braintree_card_code", Spree.t(:card_code) %><span class="required">*</span><br />
+      <%= label_tag "braintree_card_code", I18n.t('spree.card_code') %><span class="required">*</span><br />
 
       <label for="braintree_card_code" id="braintree_card_code" class="braintree-hosted-field card-code"></label>
-      <%= link_to "(#{Spree.t(:what_is_this)})", spree.cvv_path, :target => '_blank', "data-hook" => "cvv_link", :id => "cvv_link" %>
+      <%= link_to "(#{I18n.t('spree.what_is_this')})", spree.cvv_path, :target => '_blank', "data-hook" => "cvv_link", :id => "cvv_link" %>
     </p>
   </div>
 
@@ -52,4 +52,5 @@
 
   <%= hidden_field_tag "#{param_prefix}[cc_type]", '', :id => "cc_type", :class => 'ccType' %>
   <%= hidden_field_tag "order[payments_attributes][][payment_method_nonce]", '', :id => "payment_method_nonce" %>
+  <%= hidden_field_tag "braintree_client_token", braintree_client_token_for(@order.user) %>
 </div>

--- a/db/migrate/20190124223445_add_braintree_customer_id_to_spree_user.rb
+++ b/db/migrate/20190124223445_add_braintree_customer_id_to_spree_user.rb
@@ -1,0 +1,5 @@
+class AddBraintreeCustomerIdToSpreeUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :spree_users, :braintree_customer_id, :string, index: true
+  end
+end

--- a/lib/assets/javascripts/spree/backend/braintree/solidus_braintree.js
+++ b/lib/assets/javascripts/spree/backend/braintree/solidus_braintree.js
@@ -5,21 +5,14 @@ Spree.routes.payment_client_token_api = Spree.pathFor("api/payment_client_token"
 var braintreeDropinIntegration;
 var paymentForm = "#new_payment";
 var cardSelector = "#new_payment [name=card]";
+var braintreeClientTokenSelector = '#braintree_client_token';
 
 var getClientToken = function(onSuccess) {
-  return Spree.ajax({
-    url: Spree.routes.payment_client_token_api,
-    type: "POST",
-    data: {
-      payment_method_id: $('form input[type=radio]:checked').val()
-    },
-    error: function(xhr, status) {
-      show_flash("error", xhr.responseJSON.message);
-    },
-    success: function(data) {
-      onSuccess(data);
-    }
-  });
+  var data = {
+    client_token: $(braintreeClientTokenSelector).val()
+  };
+
+  onSuccess(data);
 };
 
 var attachDropIn = function(data) {

--- a/lib/assets/javascripts/spree/frontend/braintree/solidus_braintree.js
+++ b/lib/assets/javascripts/spree/frontend/braintree/solidus_braintree.js
@@ -19,26 +19,15 @@ Spree.routes.payment_client_token_api = Spree.pathFor("api/payment_client_token"
 var braintreeDropinIntegration;
 var cardSelector = "#payment-method-fields";
 var confirmForm = "#checkout_form_confirm";
+var braintreeClientTokenSelector = '#braintree_client_token';
 var paymentId;
 
 var getClientToken = function(onSuccess) {
-  return Spree.ajax({
-    url: Spree.routes.payment_client_token_api,
-    type: "POST",
-    data: {
-      payment_method_id: paymentId
-    },
-    error: function(xhr, status) {
-      // If it fails it means the payment method was not a Braintree payment method
-      if (braintreeDropinIntegration) {
-        braintreeDropinIntegration.teardown();
-        braintreeDropinIntegration = null;
-      }
-    },
-    success: function(data) {
-      onSuccess(data);
-    }
-  });
+  var data = {
+    client_token: $(braintreeClientTokenSelector).val()
+  };
+
+  onSuccess(data);
 };
 
 var initializeBraintree = function(data) {

--- a/spec/cassettes/Spree_Admin_BraintreeClientTokenController/POST_create/with_a_payment_method_id/returns_a_client_token.yml
+++ b/spec/cassettes/Spree_Admin_BraintreeClientTokenController/POST_create/with_a_payment_method_id/returns_a_client_token.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.94.0
+      X-Apiversion:
+      - '5'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic eW05ZGp3cXBreGJ2M3h6dDo0Z2hnaGt5cDJ5eTZ5cWM4
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 19 Feb 2019 20:43:11 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Authentication:
+      - server_to_server
+      Braintree-Service-Origin:
+      - clientauth
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"b657211e7056cbea0021fe0b300f251f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 84254490-1210-49ea-86d7-7e16a888a6a7
+      X-Runtime:
+      - '0.014541'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAF9qbFwAA3yVXXObOhCG7/MrMrnvKQiTE2aSdOIPMIyFa2wj0J2RiAFLmFPbYPj1Z4XTJpm6vWDsAe3Xu8+uHr+dpbit0x+HfF8+3en/aHe3acn2PC+3T3frlf3l4e7b880jE3laHr8c97u0fL65vX2sN+KUPqeth2jkdRtindxi385GXsajYJ8YXpVKW1PvAylOFIUtm3pVUi7yee4JfxzmdMVajAIZE6zFxMspmTR49YLmY4bgf+evmBEjX9IxlZh42XwcFLhjOib2zu9eWizXWrxiCBPwscLaq+O3lNgaJcFrHC0sXLyc50utwbl2noeLFo/3Gu72Z7wctPOx2+Bu0uFi/QOPXxpsn3X4bX2pCyb9fUxMLUJi9z2q8qQIzbScmHzMjSTiA3/sMb4Cm4I2nHiHDfFfNyg0v0fiOCfBf9ywm42R5bzwBynUC5oUCTLlhvCQyUbVv+fToGHdvp4hOLs0O4i3i6U1mEmvjYk48aknKOEZd0IjjnanGFnHebHQcGsdQe9i49hwBtep9E5+JO7ZSmi+wY/c2Go4t4rEESIplQ7DambE5xny60TSihphG0dBlaCByqtkEuLbNnaL6l+3DNtk5N67MtP4dNjN84eaObaZkFDFOjFkn6jj1enIzMEOehmA3utjH0OC/6V18Te1D27e5NSBXizBXwFar7ZHPF7Ds81fl00eoyxLnLNIJBesde+Jrh1cCXGkaEGrIwX9gaf8PaYL333QGs5MIEb4e659HqWfJTLIE2N7iksv24AfJkNBEeQS8SxdmtAL7d4fL7oZeu81a637WA70NKrO82hhcKQb6XjRgm6XmLaVMWenNMuY4Qs+9a/1smMoBF8f9QlL0FtwZJsXjVQdts6d7Jo9vN+CBuEpIQ9/0Puqv1NMziZ3RKG0hJnUf/dttcBfleQ66GMfUmAgNvCxjzH6A39LXdXcszczrs2B2/cSalF5TdYoLHjkiYCYWSzPgkJ/wI9O4YziCJ7D3771DMqgYsbwEEdiHhNdKAbWxlBxdpmjC9eesk/K8JCMwB72Cpd2kX5i4uV+1loidewjA87e+GyY4qgMO5ihITXUjOnK36deKJZoBHxGwwO98FJzx+oU07G0O3qVPR98Bt3f5re3fzsXRt5B1baZBhqbYpUrzHRYbJCl85HZQP1NTJpfdtQRoIGvLT7E/1k/9P6QGNxVuYOGGitDAVpBXbRi0jr18zsx65UMNa44aN+1hzlDm8iD3aB06HdzTSUF5k2h4nL4Dvmqner/2jsQmwJDDK2BvQ/1rn/Op9ip2hJid1B/G6NzpeYZt4pVuAOccwVz/1H/7hoXkHfb74kyGMI9UEMu2pL0OXas57PfCToroVbpm8vIrxfI2vU7R4SrYORZoMP7vnzL6/rOVFxQ8KPXfe6ISrfUnh6/Xu65m8evn2/A/wEAAP//AwBWBe3oOAcAAA==
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 20:43:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_Admin_BraintreeClientTokenController/POST_create/with_a_payment_method_id/returns_a_content_type_of_application/json.yml
+++ b/spec/cassettes/Spree_Admin_BraintreeClientTokenController/POST_create/with_a_payment_method_id/returns_a_content_type_of_application/json.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.94.0
+      X-Apiversion:
+      - '5'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic eW05ZGp3cXBreGJ2M3h6dDo0Z2hnaGt5cDJ5eTZ5cWM4
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 19 Feb 2019 20:43:10 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Authentication:
+      - server_to_server
+      Braintree-Service-Origin:
+      - clientauth
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"04968ff8cc953561d4d764e890b7f8d4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 82fe6aa9-d5f4-4880-8d76-7007a8ecb1b1
+      X-Runtime:
+      - '0.236762'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAF5qbFwAA3yVW3ObOhDH3/spMnnvKYiQU2bSdmITMIwl19gGpDcjkQCWMKe+cPn0Z4XbJp26fWDsAe3tv79dPXzplLw5598O5b7+dGv+Y9ze5DXfi7J++XS7WXvvP95++fzugcsyr4/vj/tdXn9+d3PzcN7KU/4570PE0nDYJs4pqPb9fBoWIo32mRU2ufIM/T5S8sRQ3PNZ2GT1slyUQc8qUtK1kHgdS+JOdjjxCopYgavHgblPA0koPLjFCStpQjuSbDo8EEXcaEernclcPuAkMBbu0maJV+G1KJ590sN/gyXRM02XDvjqFiujxaXRLeJlj929gYd9h6d3Bl4/IuwuEak237D72GKvM+G3J8qUXJE9TWwjRXL3NW3KrIrtvH6yhSusLBV3xA25WINNxVqRhIdtQp63KLa/pvK4SKL/hOW1W6soRUXucqgXNKkyZKttImKuWqg/3ItZ1PJhf54jOLuyB4i3o8q5m6uwp4k8iVkoWSIK4ccWTXcnipzjoloauHeOoHe19T04g8+5Ck8klfd8LQ1iiaOwXgxcOlXmS5nVWodJM7doN0fknCnWMCvuaRo1GbrTedVcQXzPw0HV/BvUcZ9Ng/tAFYaYTYZF+fHMfc/OkljHOnHknZgfnvOpXYId9DICvTfHMYYC/yvn4m/mHYKyLZkPvViBvypo8frliN0NPC/l86otKSqKzO9kpoTkfXCfmMYhUBBHyR60OjLQH3gqX2MG8J2A1nDmCWLEv+c65lGTIlNRmVkvJ1qHxRb8cBVLhiCXVBT5yoZeGPfEXQ5z9Npr3jv3VN2Zedp0i3RpCWRaubvsQbdLTM8puL/TmhXcIlLMyLVeDhzF4OutPnENekuBPPuika7DM4VfXLOH9y+gQXzKko9/0PuqvxNNOlv4stJawkyav/t2euCvyUoT9PEOOTBALXwcY0z/wN/K1DWP7M2ta3MQjL2EWnReTxsUVyINZZTYBVWdZNAf8GMyOKM5gufwt28jgypquDU50FQuaGJKzcDGmmjOLnN04TrU9lkdH7Ip2MNeEcqr8l+YeLyf947Mfe/IgbPvfLZcc1THA8zQhFl6xkzt75deaJZYCnymkwO78HIWvjNopqnyBnaVPQI+o+Fv8zvafz8Xp+FB17adRQafYZ0rzHRcbZFjiqndQv0tTdqfdsyXoAExlm/i/6gfen/ILBHo3EFDg9exBK2gLtZw5ZzG+X2yz2sVG0Jz0L9qD3OGtmkIu0HroHdzeGaKAfO21HEFfId89U4lP/cOxGbAEEcbYO9NvZsf8yl3urYs8Qaov6eoa/Q8416zCneA3zUw92/1H65xAXn3456oowmF/QW5GKtkzHHgI5/jTjB5DbUqYq9Scl4iZzfuHBmvo2nogA6v+/J7Xtd3puaCgR/zPOaOmApq49PDh8s99+7hw6834P8AAAD//wMAvobKxTgHAAA=
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 20:43:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_Admin_BraintreeClientTokenController/POST_create/with_a_payment_method_id/returns_an_http_success.yml
+++ b/spec/cassettes/Spree_Admin_BraintreeClientTokenController/POST_create/with_a_payment_method_id/returns_an_http_success.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.94.0
+      X-Apiversion:
+      - '5'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic eW05ZGp3cXBreGJ2M3h6dDo0Z2hnaGt5cDJ5eTZ5cWM4
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 19 Feb 2019 20:43:09 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Authentication:
+      - server_to_server
+      Braintree-Service-Origin:
+      - clientauth
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"7eaa8a843c17171f6509ad3a8e0286ab"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 50291347-9029-458d-8ab9-e51ea3a26830
+      X-Runtime:
+      - '0.381982'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAF1qbFwAA3yVXXObOhCG7/MrMrnvKQjjE2aSdGI7YBiDC7YB6c5IxIAlzKltvn79WeG0SaZuLxhmkPbr3WeXh2+t4Ld1+uOYH8rHO/Uf5e42LemB5eXu8W6zNr/c3317unmgPE/L05fTYZ+WTze3tw/1lp/Tp7RzEImdfhsZZ7s4dIupk7E4OCSaU6XCVOT3QPAzQWFH506VlH6+zO0OC79fzmwFR66Ce7tzI9wQ4eVk5vZLa9O462fNjcLMneHWLTZw90XFBXxHHvfWe51EwX5p+Rpeb3pvtuldsRm9Wl5HIlOBs1cc+4ZbPLfLldK4udIuQ79zZwfF7Q/NcjVC7tpX3WKnwvuHO3tuXLNV4d15QuVUeAcc6UqM+P57XOVJEepp+aKzGdOSmI28mUPZGmwK0rDIOW4j73WLQv17zE/LKPiPaWaz1bKcFd4ohXpBkyJButhGLKSigfqdA5sHDe0P9QLB3ZXeQ7w9FsZoIZwOR/zM5g4nEcuYFWo43p8xMk7LwlfczjiB3sXWMuGOW6fCOXsxH9M1VzyNnZi2U9zcKBKL86SUOkyqhYbbBfLqRJCKaGGH46BK0EjmVVIB8U3TtYvqX7sMu2Rqj22RKWw+6Zf5fU0tU0+iUMY6U2SeieXU6VTPwQ56GYDem9MQQ4D/lXHxNzePdt7kxIJerMBfYUM/dyd3toFnl7+umhyjLEuslieCcdrZ40hVjraAOIJ3oNWJgP7AU/4e04ZzD7SGOy8QI/w91yGP0ssSEeSJtjvj0sm24IeKkBMEucQsS1c69EIZezO/X6D3XtPOGGMxUtO4apexrzGkaunM70C3S0zTyKi1l5plVPM4m3vXetlTFIKvj/qEJejNGTL1i0ayDlNlVnbNHr7vQIPwnET3f9D7qr8zjlqdWbyQWsJMqr/7Njrgr0pyFfQxjykwgDX3NMSY/oG/lSprHthbaNfmwB56CbXIvF42KCxY7PAg0jMsWk6gP+BHJXBHcgTP8W9nA4MiqKg2OeKYL3GkcsnARptIzi5zdOHakfZJGR6TKdjDXmHCLNJPTDyPF53BU8s8UeDsjc+GSo7KsIcZmhBNzpgq/X3qhWSJxMBnPDmSCy81s4xeMo2F2ZOr7HngM+j/Nr+D/du9MHaOsrbtPFDo3JW5wkyHxRYZKpvqDdTf4Kj5ZUcsDhp4iv8h/s/6offHRGO2zB00VGgZctAK6iIVFcZ5mN8XvV6LUGGSg+5de5gztI0d2A1SB7mbnZoIAszrXMZlcA75yp3q/do7EJsAQxRtgL0P9W5+ziffy9qSyOyh/g6jtpLz7HaSVfgHWG0Fc/9R//4aF5B3N+yJMphg2F+Qi7KKhhx7OvA57ASVllCr8PRV7NU+MvbDzuHhOpg6Bujwvi/f8rq+MyUXBPyo9ZA7IsIulceHr5f/3M3D189/wP8BAAD//wMAKpbg6jgHAAA=
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 20:43:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_Admin_BraintreeClientTokenController/POST_create/without_a_payment_method_id/returns_a_client_token.yml
+++ b/spec/cassettes/Spree_Admin_BraintreeClientTokenController/POST_create/without_a_payment_method_id/returns_a_client_token.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.94.0
+      X-Apiversion:
+      - '5'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic eW05ZGp3cXBreGJ2M3h6dDo0Z2hnaGt5cDJ5eTZ5cWM4
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 19 Feb 2019 20:43:12 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Authentication:
+      - server_to_server
+      Braintree-Service-Origin:
+      - clientauth
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"21148f203434726fab558053cb74e96b"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b71baf26-d9dc-494a-ab0e-782d6e80d24a
+      X-Runtime:
+      - '0.014880'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAGBqbFwAA3xVXXObOhB9z6/I5L23fBjfMJOkE9sBw1i4xhiQ3oxEDFjC3Nrm69ffFU6bZOr2gRek3XP27NnVw7dW8Ns6/XHMD+XjnfqPcneblvTA8nL3eLcJrC/3d9+ebh4oz9Py9OV02Kfl083t7UO95ef0Ke1cjcRuv43Ms1McusXUzVjsHxLdrVJhKfK/L/iZaGFH526VlKt8mTsq7tEIBasOaSsDzZ471D8bKNiMvMjNcfHckmDX42DTooDlKPByIrCBhNPinhdegVUcYYPYL6NltDFQtNG9gBWvtteRyFJI5L/ieGUiyLNcKw3KlXYZAtbsoKD+0KJ81KDZrkezVb8Mdj8Av0FWq0oenlA5Fd4BR4YSa3z/Pa7ypAiNtHwx2IzpScxG3sylLICYgjQsco/byHvdaqHxPeanZeT/x3Sr2epZzgpvlEK9oEmRaIbYRiykooH63QOb+w3tD/VCg7trowe8PRbmaCHcDkf8zOYuJxHLmB3qON6fsWaelsVKQZ15Ar2LrW3BHVSnwj17MR/TgCuezk5M3ykoN4vE5jwppQ6TaqHjdqF5dSJIRfSww7FfJdpI8iqpAHzLQk5R/euUYZdMnbEjMoXNJ/0yv6+pbRlJFEqsM9WsM7HdOp0aOcRBL33Qe3MaMATkX5uXfHPr6ORNTmzoxRryFU6Dgt0JzTbw7fLXdZNjLcsSu+WJYJx2zjhSlaMjAEfwDrQ6EdAf/JS/Yzpw7oHWcOcFMMLfuQ48Si9LhJ8n+u6MSzfbQh4qQk404BKzLF0b0Atl7EHvF9p7r2lnjrEYqWlctct4pTNN1dPZqgPdLpiWmVF7LzXLqO5xNveu9bKnWgi5PuoTlqA3Z5plXDSSdVgqs7Nr8fB/BxqE5yS6/4PeV/OdcdQazOaF1BJmUv09t9mB/6okV0Ef65iCB7COTgPG9A/+W6uy5sF7C/3aHDhDL6EWyetlo4UFi13uR0aGRcsJ9AfyqATuSB/Bd/zb2eBB4VdUnxxxzJc4Urn0wEafSJ9d5ujia1fGJ2V4TKYQD3uFCatIP3niebzoTJ7a1omCz9782VDpozLsYYYmRJczpsp8n3ohvURi8Gc8OZKLX2pmm730NBZWT656z4Ocfv+3+R3i3+6FsXuUtW3nvkLnSHKFmQ6LrWaqbGo0UH+Do+ZXHLE5aOApqw/4P+uH3h8TnTmSO2io0DLkoBXURSoqzPMwvy9GHYhQYdIH3bv2MGfaNnZhN0gd5G52ayIIeN7gEpfBOfCVO9X7tXcAm4CHqLYB732od/NzPvle1pZEVg/1d1hrKznPqJNehTfAbiuY+4/699d8Aby7YU+U/gTD/gIuyjoaOPZ08OewE1RaQq3CM9axV680cz/sHB4G/tQ1QYf3ffnG6/rOlL4gkEetB+4aEU6pPD58vbxzNw9fP7+A/wMAAP//AwADGnBLOAcAAA==
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 20:43:12 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_Admin_BraintreeClientTokenController/POST_create/without_a_payment_method_id/returns_a_content_type_of_application/json.yml
+++ b/spec/cassettes/Spree_Admin_BraintreeClientTokenController/POST_create/without_a_payment_method_id/returns_a_content_type_of_application/json.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.94.0
+      X-Apiversion:
+      - '5'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic eW05ZGp3cXBreGJ2M3h6dDo0Z2hnaGt5cDJ5eTZ5cWM4
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 19 Feb 2019 20:43:11 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Authentication:
+      - server_to_server
+      Braintree-Service-Origin:
+      - clientauth
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"14a80c334ab692ddb66363ab3721145c"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 4bbc7d62-59f3-44d5-9346-de4f9760def1
+      X-Runtime:
+      - '0.012807'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAF9qbFwAA3yVXXObOhCG7/MrMrnvKR/GJ8wk6cR2wDCWqLENSHdGIgYsYU79geHXnxVOm2Tq9oLxjJF293332eXh21mK21P2Y1/sqsc7/R/t7jar2I4X1ebxbrV0vtzffXu6eWCiyKrDl8Num1VPN7e3D6e1OGZPWesbNPG7dWwfvXLXzsZ+zpNwl5p+nUlHU/+HUhypEbVs6tdpNS+CwmvRMspJ7Gmk2wyCCTGDJWlRjLekQ1aw5DnuohKXvsTL7SBwiYU6T8dwHrmeHkxeLFSKLZKRoDEy6ZLpSOLtq4tbGjsajcNXksxtVD6fg4XWoEI7B9G8RZOdhrrdGS0GJi6JhpcrDZfoB5o8N8g56/DbYqkLJvGOxJaWGGL7PamLtIysrHqx+ISbacIHeOIzvoQ7JW147O/XMX5dG5H1PRGHIA7/46bTrM284CUeZKAXPClTw5LrmEdMNqDf3/Fp2LBud5oZcHZhdZBvS6Q9mEm/JbE48qkP2njO3cgkyfZIDPsQlHMNtfYB/C7XrgNn0CmT/hEnYsiWQsMmP3Bzo6HCLlNXiLRSPozqmUnOMwOfUklrakYtScI6NQaqropJyO84yCvrf70qatOxN/RkrvHpqAuK+xNzHSuNI5XryAznSF3/lI2tAu5BL0Pwe3Xoc0iIv7Av8abO3iuagrrQiwXEK70GLTcHNFnBsyleF01BjDxP3bNIJRes9Yaxru09CXmkaMGrAwX/gafiPacH7zF4DWdeIEf0e619HRXOUxkWqbk5ksrP1xCHKU4MqCXhebawoBfaEE/m3cx47zVr7SGRAz1L6nOQzE1u6GY2mbfg2yWnY+fM3SrPcmZiwaf4Wi87ZkQQ66M/UQV+C2441sUjpcPRuZtfuw//b8CD6JjG93/w+2q8I4nPFndFqbyEmdR/j223wF+dFjr44+wzYICY6NDnGP+Bv4WuNPfszcxrc+D1vQQtqq6XlRGVPPFFGFs5kWdBoT8QR6dwRnEEz/5v73oGZVgzc7QniQhIrAvFwMocKc4uc3Th2lf30yrap2O4D3uFS6fMPjHxPJy1tshc58CAszc+G6Y4qqIOZmhETTVjuor3qReKJZoAn8loTy+8nLhrd4ppIp2OXmUPQ8yw+9v89vffzkWJv1fa1tNQY1OkaoWZjsq1Yet8bDWgvyFx8+sedQV4gLX5h/w/9UPv96nJPVU7eKixKhLgFeiiNZP2sZ/fF+u0lJHGFQftu/cwZ8Y68WE3KB/UbvZPVFJg3hIqL4f3UK/aqfjX3oHcFBhixgrY+6B39XM+xVZpS2OnA/0tMc61mmfUKlbhG+Cea5j7j/5317iAutt+T1ThiMD+glq0RdzX2LGez34n6KwCrRJbiwSf5oa97XeOiJbh2LfBh/d9+VbX9Z2puKAQRz/1tRtUepX2+PD18p27efj6+Qv4PwAAAP//AwBCb3ZrOAcAAA==
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 20:43:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_Admin_BraintreeClientTokenController/POST_create/without_a_payment_method_id/returns_an_http_success.yml
+++ b/spec/cassettes/Spree_Admin_BraintreeClientTokenController/POST_create/without_a_payment_method_id/returns_an_http_success.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.94.0
+      X-Apiversion:
+      - '5'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic eW05ZGp3cXBreGJ2M3h6dDo0Z2hnaGt5cDJ5eTZ5cWM4
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 19 Feb 2019 20:43:11 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Authentication:
+      - server_to_server
+      Braintree-Service-Origin:
+      - clientauth
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"2b7dec65f175156103077f15f2df3a60"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - cb8a851a-de9d-4f9c-a632-f6c91eaa02d0
+      X-Runtime:
+      - '0.016783'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAF9qbFwAA3yVXXObOhCG7/srMrnvKYiQU2aSdGoTMIwl19gWoDsjEQOWMKf+wPDrzwqnTTp1e8Ewg7Rf7z67PHw5K3lzyr/vy139eGv+Y9ze5DXfibLePN6ult7Hz7dfnj48cFnm9eHjYbfN66cPNzcPp7U85k95FyKWhP06do5Bteum47AQSbTLrLDJlWfo75GSR4Zoxydhk9XzclaGFXGpxC6tsCIl6cUW9xE8QTvzo22KViauni3Scxv3VDJ3YxMf9xjN9XmZ9oFN4rTH/dycuSM1c6libihffNKx2DNYHL2kydzB1dfzbGG0uDTOMzrvsLszcL8748WdiftVhytuETf9jt2vLfbOJrw7okzJFdmlsW0kSG6/JU2ZVdTO62dbuMLKEnFH3JCLJdhUrBVxuF/H5GWNqP0tkYdZHP0nLK9dW0UpKnKXQ72gSZUhW61jQblqdf07MYla3u9OUwR3F3YP8bapcu6mKuzSWB7FJJQsFoXwqZUm22OKnMOsmhu4cw6gd7X2PbiDT7kKjySR93wpDWKJg7A2Bi6dKvOlzGqtw6iZWul5isgpU6xhFu3SJGoydKfzqrmC+J6Hg6r5N6hpl42D+0AVhpiM+ln5+cR9z85iqmMdOfKOzA9P+dguwQ56GYHeq8MQQ4H/hXPxN/H2QdmWzIdeLMBfFbR4uTlgdwXPpnxZtGWKiiLzzzJTQvIuuI9NYx8oiKNkB1odGOgPPJVvMQM4J6A13HmGGPT3XIc8alJkKioza3NM67BYgx+ugCEEuSSiyBc29MK4J+68n6K3XvPOuU/VnZknzXmWzC2BTCt35x3odonpOQX3t1qzAqiRYkKu9bLniIKv9/rQGvSWAnn2RSNdh2cKv7hmD983oAE9ZvHnP+h91d8xjc+28GWltYSZNH/37XTAX5OVJujj7XNgILXwYYgx/gN/C1PXPLA3ta7NQTD0EmrReT2vEK1EEsoototUnSWD/oAfk8EdzRE8+7+dDQyqqOHWaJ8mcpbGptQMrKyR5uwyRxeuQ22f1XSfjcEe9opQXpX/wsTX+2nnyNz3Dhw4e+Wz5ZqjmvYwQyNm6Rkztb9feqFZYgnwmYz27MLLSfhOr5lOldezq+wR8Bn1f5vfwf71Hk3Cva5tPYkMPsE6V5hpWq2RY4qx3UL9bRq3P+2YL0EDYszfxf9RP/R+n1ki0LmDhgavqQStoC7WcOUch/l9tk9LRQ2hOejetIc5Q+skhN2gdRh284kpBszbUscVcA756p1Kfu4diM2AIY5WwN67elc/5lNudW1Z7PVQf5eic6PnGXeaVfgH+OcG5v69/v01LiDvbtgTdTRKYX9BLsYiHnLs+cDnsBNMXkOtitiLhJzmyNkOO0fSZTQOHdDhbV++5nV9Z2ouGPgxT0PuiKmgNh4fPl3+cx8ePv36B/wfAAD//wMA4PGgUzgHAAA=
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 20:43:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_BraintreeClientTokenController/POST_create/with_a_payment_method_id/returns_a_client_token.yml
+++ b/spec/cassettes/Spree_BraintreeClientTokenController/POST_create/with_a_payment_method_id/returns_a_client_token.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.94.0
+      X-Apiversion:
+      - '5'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic eW05ZGp3cXBreGJ2M3h6dDo0Z2hnaGt5cDJ5eTZ5cWM4
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 24 Jan 2019 22:13:43 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Authentication:
+      - server_to_server
+      Braintree-Service-Origin:
+      - clientauth
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"bb7cc1e7112fc93d1147bc705e0ed376"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 4932b425-a06f-4bd4-990e-6abe41164178
+      X-Runtime:
+      - '0.385485'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAJc4SlwAA3xVXXObOhB9z6/I5L23fBjfMJOkE5uAYYyosQ1Ib0YiBixh
+        bm2D4dffFU6bZOr2gWEGtHvOnj27evh2Fvy2yX4cin31eKf+o9zdZhXds6La
+        Pt6tV/aX+7tvTzcPlBdZdfxy3O+y6unm9vah2fBT9pR1nkYSr9/E5skt9918
+        6uUsCfep7tWZsBX5PRT8RLSoozOvTqtFERQe9y1XR9pa9VeugWOvCCwmkDUp
+        /H7R4tVLS1ZbxS/tMrCiwnfsHFmkgG8qKnEXWO4IWYjjFTZwudWxWPdBvB69
+        Oqgjsa2QOHzFycL0y+dzsFRaf6l0yF50frk/+/1e8btRG6yedb90R4D/w7ee
+        W98+q/DukFA5FWiPY0NJNL77ntRFWkZGVr0YzGJ6mjDA9ihbQUxJWhZ7h02M
+        XjdaZHxP+DGIw/+YbrcbPS9YiUYZ1AualKlmiE3MIipaWf+ezcKW9vtmrsHZ
+        pdED3g4LczQXXodjfmIzj5OY5cyJdJzsTlgzj0G5AO7mEfQuN44NZ/wmE94J
+        JXxMV1xBOjsyHXQrzDJ1OE8rqcOknuv4PNdQkwpSEz3qcBLWqTaSvCoqAN+2
+        fbes/3WrqEun7tgVucJmkz4o7hvq2EYaRxLrRDX7RByvyaZGAXHQyxD0Xh8H
+        DAH5l+Yl38w+uEVbEAd6sYR8pdv6q+3Rt9bwbIvXZVtgLc9T58xTwTjt3HGs
+        KgdXAI7gHWh1JKA/+Kl4x3ThPwKt4cwLYES/cx14VChPRVik+vaEKy/fQB4q
+        Ik404JKwPFsa0AtljKxFP9fee007c4zFSM2S+hwkC51pqp5Ziw50u2DaZk6d
+        ndQspzribIau9bKnWgS5PuoTVaA3Z5ptXDSSddgqc/Jr8fB9CxpEpzS+/4Pe
+        V/OdcHw2mMNLqSXMpPp7brMD/9VpoYI+9iEDD2DdPw4Y0z/4b6nKmgfvzfVr
+        c+AOvYRaJK+XtRaVLPF4GBs5FmdOoD+QRyVwRvoInsPf/g0eFGFN9ckBJzzA
+        scqlB9b6RPrsMkcXX3syPq2iQzqFeNgrTNhl9skTz+N5Z/LMsY8UfPbmz5ZK
+        H1VRDzM0IbqcMVXm+9QL6SWSgD+TyYFc/NIwx+ylp7Gwe3LVewhyhv3f5neI
+        fzsXJd5B1raZhQqd+ZIrzHRUbjRTZVOjhfpbHLe/4ojDQQOkLD7g/6wfen9I
+        deZK7qChQquIg1ZQF6mpME/D/L4YzUpECpM+6N61hznTNokHu0HqMOzmhggC
+        nje4xGXwH/jKnYp+7R3AJuAhqq3Bex/qXf+cT76TtaWx3UP9HdbOtZxnv5Ne
+        hTvAOdcw9x/176/5Anh3w56owgmG/QVclGU8cOzp4M9hJ6i0gloFMpYJahaa
+        uRt2Do9W4dQzQYf3ffnG6/rOlL4gkEdtBu4aEW6lPD58vdxzNw9fP9+A/wMA
+        AP//AwB/uESMOAcAAA==
+    http_version: 
+  recorded_at: Thu, 24 Jan 2019 22:13:43 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_BraintreeClientTokenController/POST_create/with_a_payment_method_id/returns_a_content_type_of_application/json.yml
+++ b/spec/cassettes/Spree_BraintreeClientTokenController/POST_create/with_a_payment_method_id/returns_a_content_type_of_application/json.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.94.0
+      X-Apiversion:
+      - '5'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic eW05ZGp3cXBreGJ2M3h6dDo0Z2hnaGt5cDJ5eTZ5cWM4
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 24 Jan 2019 22:13:42 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Authentication:
+      - server_to_server
+      Braintree-Service-Origin:
+      - clientauth
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"4505e00006088556d8243aad7b156e97"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 442377ef-f3de-43be-a9c0-3521df8a1e26
+      X-Runtime:
+      - '0.013557'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAJY4SlwAA3yVXXObOhCG7/MrMrnvKQiTE2aSdOIPMIyRa2wD0p2RiAFL
+        mFPbYPj1Z4XTJpm6vfB4BqTdfd99dnn8dpbitk5/HPJ9+XSn/6Pd3aYl2/O8
+        3D7drVf2l4e7b883j0zkaXn8ctzv0vL55vb2sd6IU/qcth6isddtIuvkFvt2
+        NvIyHgf7xPCqVNqaeh5IcaIobNnUq5Jykc9zT5JoMaBybZAu2JFi22KH7vzV
+        xPS7HSKIDEiXSTx+OdPVQqeFr80dX/c7ZuCCSoJ8nawWGo5wjosXRItJA88G
+        rw5uaWRrNApeSbyw/OLlPF9qjb/UWmwvWr/Yn/1ur/n5YAC5On9MuvnY/eGP
+        XxrfPuvw32KpCybxnkSmFiOx+x5XeVKEZlpOTD7mRhLzAR57jK/gTkEbHnmH
+        TYRfNyg0v8fiOI+C/7hhNxsjy3mBBynoBU+KBJlyE/GQyUbp3/Np0LBuX88Q
+        nF2aHeTbEWkNZtJrSSROfOoJGvGMO6FB4t2JIOs4Lxaa31pH8LvYODac8etU
+        eicci3u2Eho2+JEbW9BnFYkjRFIqH4bVzCDnGcJ1ImlFjbAlcVAlaKDqKpmE
+        /Lbtu0X1r1uGbTJy712ZaXw67Ob5Q80c20yiUOU6MWSfqOPV6cjM4R70MgC/
+        18c+h4T4S+sSb2of3LzJqQO9WEK8wm381fboj9fw2+avyyYnKMsS5ywSyQVr
+        3ftI1w6uhDxStODVkYL/wFP+ntOF9xi8hjMTyBH+XmtfR4mzRAZ5YmxPpPSy
+        DcRhMhQUQS0xz9KlCb3Q7vF40c3Qe69Za90TOdDTuDrP44XBkW6k40ULvl1y
+        2lbGnJ3yLAMKBZ/ia73sGAoh1kd/whL8FhzZ5sUjpcPWuZNduw/Pt+BBeEqi
+        hz/4fTXeiURnkzuiUF7CTOq/x7Za4K9Kch38sQ8pMEAM/9jnGP2Bv6WuNPfs
+        zYxrc+D2vQQtqq7JGoUFjz0RRGZG5FlQ6A/E0SmcURzB7/C3dz2DMqiYMTyQ
+        WMxJpAvFwNoYKs4uc3Th2lP3kzI8JCO4D3uFS7tIPzHxcj9rLZE69pEBZ298
+        NkxxVIYdzNCQGmrGdBXvUy8USzQGPuPhgV54qbljdYppIu2OXmUPQ8yg+9v8
+        9vffzoWxd1DaNtNAY1Nf1QozHRYbZOl8ZDagvyFR8+sedQR4gLXFh/w/9UPv
+        D4nBXVU7eKixMhTgFeiiFZPWqZ/fiVmvZKhxxUH77j3MGdrEHuwG5UO/m2sq
+        KTBvCpWXw3uoV+1U/GvvQG4KDDG0BvY+6F3/nE+xU9qSyO5Af0vQuVLz7LeK
+        VfgGOOcK5v6j/901LqDutt8TZTAksL+gFm0Z9TV2rOez3wk6K0GrxOYyxvUC
+        Wbt+54hwFYw8C3x435dvdV3fmYoLCnH0uq8dUemW2tPj18t37ubx6+cv4P8A
+        AAD//wMAxAr47DgHAAA=
+    http_version: 
+  recorded_at: Thu, 24 Jan 2019 22:13:42 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_BraintreeClientTokenController/POST_create/with_a_payment_method_id/returns_an_http_success.yml
+++ b/spec/cassettes/Spree_BraintreeClientTokenController/POST_create/with_a_payment_method_id/returns_an_http_success.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.94.0
+      X-Apiversion:
+      - '5'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic eW05ZGp3cXBreGJ2M3h6dDo0Z2hnaGt5cDJ5eTZ5cWM4
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 24 Jan 2019 22:13:42 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Authentication:
+      - server_to_server
+      Braintree-Service-Origin:
+      - clientauth
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"2b607db79a082a74433ed009bc750409"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b783070a-f7ee-40a4-bbbb-6bea96629625
+      X-Runtime:
+      - '0.364260'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAJY4SlwAA3xV23KbSBB991e4/J4NF+E1VbZT1gUEJYYIScDMm5jBAjSD
+        2Eji9vXbg5zYrih5oChguvuc06ebx2+t4Ld1+uOYH8qnO/Uf5e42LemB5eXu
+        6W6ztr483H17vnmkPE/L05fTYZ+Wzze3t4/1lp/T57RzNRK7/TYyz05x6BYT
+        N2NxcEh0t0qFpcj3geBnooUdnbtVUi5zP3d63Lu5v6YdLvY9LqjhRzMViVnr
+        rRHHArfEnvVe4Y3wetki4Rb+dNOjNdkjeMYa7pDwGj/yGoiHZ1L463H+aqOO
+        RJZCouAVx0vTK15af6U03krpkLXsvOLQev1B8fJR5/WO4U33Opp6P7zpS+NZ
+        rQp3yKtyKtABR4YSa3z/Pa7ypAiNtJwZbMr0JGYjNHUpW0NMQRoWucdthF63
+        Wmh8j/nJj4L/mG41Wz3LWYFGKfAFTYpEM8Q2YiEVDfB3D2weNLQ/1AsNzq6M
+        HurtsTBHC+F2OOJnNnc5iVjG7FDH8f6MNfPkF0vF68wT6F1sbQvOeHUq3DOK
+        +T1dcwXp7MT0HfAzi8TmPCmlDuNqoeN2oaE6EaQietjhOKgSbSRxlVRAfcvy
+        nKL61ynDLpk4947IFDYf937+UFPbMpIolLXOVLPOxHbrdGLkEAe9DEDvzWmo
+        ISD/yrzkm1tHJ29yYkMvVpCvcBpvvTt50w1cu/x11eRYy7LEbnkiGKedcx+p
+        ytERUEfwDrQ6EdAf/JS/13TgOwKt4cwMaoS/Yx1wlChLRJAn+u6MSzfbQh4q
+        Qk40wBKzLF0Z0AvlHk2X/UJ77zXtzHssRmoaV60fL3WmqXo6XXag26WmZWbU
+        3kvNMqojzuboWi97qoWQ66M+YQl6c6ZZxkUjycNSmZ1di4f3O9AgPCfRwx/0
+        vprvjKPWYDYvpJYwk+rvuc0O/FcluQr6WMcUPIB17zTUmPzBfytVch68t9Cv
+        zYEz9BK4SFyzjRYWLHZ5EBkZFi0n0B/IoxI4I30E1/Fv3wYPiqCi+viIY+7j
+        SOXSAxt9LH12maOLr10Zn5ThMZlAPOwVJqwi/eSJl/tFZ/LUtk4UfPbmz4ZK
+        H5VhDzM0JrqcMVXm+9QL6SUSgz/j8ZFc/FIz2+ylp7GwenLVewhyBv3f5neI
+        fzsXxu5RctvOA4XOPYkVZjostpqpsonRAP8GR82vOGJz0AApyw/1f/KH3h8T
+        nTkSO2io0DLkoBXwIhUV5nmY35lRr0WoMOmD7l17mDNtG7uwG6QOcje7NREE
+        PG9wWZfBd8Ardyr6tXegNgEPUW0D3vvAd/NzPvlecksiqwf+HdbaSs6z10mv
+        wj/AbiuY+4/699d8Abi7YU+UwRjD/gIsyioaMPZ08OewE1RaAleBjFWM6qVm
+        7oedw8N1MHFN0OF9X77hur4zpS8I5FHrAbtGhFMqT49fL/+5m8evn/+A/wMA
+        AP//AwDmEbm0OAcAAA==
+    http_version: 
+  recorded_at: Thu, 24 Jan 2019 22:13:42 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_BraintreeClientTokenController/POST_create/without_a_payment_method_id/returns_a_client_token.yml
+++ b/spec/cassettes/Spree_BraintreeClientTokenController/POST_create/without_a_payment_method_id/returns_a_client_token.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.94.0
+      X-Apiversion:
+      - '5'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic eW05ZGp3cXBreGJ2M3h6dDo0Z2hnaGt5cDJ5eTZ5cWM4
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 24 Jan 2019 22:17:33 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Authentication:
+      - server_to_server
+      Braintree-Service-Origin:
+      - clientauth
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"91a895126cb2ddc4e11181b0893baf6b"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 18eb6f09-7879-48e5-9872-a30ae81e98fb
+      X-Runtime:
+      - '0.014237'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAH05SlwAA3yVW3ObOhDH3/MpMnnvKQiTE2aSdOILGMbINba56M1IxIAl
+        zKnN9dOfFU6bZOr2gbEHVnv5729Xj99awW/r5McpOxZPd+o/yt1tUtAjy4r9
+        0912Y355uPv2fPNIeZYU5y/n4yEpnm9ubx/rHa+S56RzEAmdfhcYlZ0fu8XE
+        SVnoHWPNKRNhKvK9J3hFkN/RuVPGxSpbZrYabfb90opGRDhp1OOUbGYdCRxO
+        clcnFha4t5soIIKICBHL7sG+dUWkuZs0dS23w8hL3R6sxVaB/xm2ZsqrhcGH
+        qZDAe43CleHmL+1yrTTuWumwuerc/Nji/ti73UhfTg86nu7hWf1wpy+Na7Yq
+        /HZYqJwKfIwCXQkRP3wPyyzOfT0pZjqbMi0O2QhPHco2cCYnDQuc0y7Arzvk
+        699Dfl4G3n9MM5udlmYsx6ME6gVN8hjpYhcwn4oG6neObO41tD/WCwS2a72H
+        eIdIGKOFcLoo4BWbgxYBS5nla1F4qCJknJf5SnE74wx65zvLBBu3ToRT4ZDf
+        0w1XsMbOTNsrbmbkscV5XEgdxuVCi9oFwnUsSEk0v4tCr4zRSOZVUAHxTdO1
+        8/Jfu/C7eGLf2yJV2HzcL7OHmlqmHge+jFVRZFbEcupkomdwDnrpgd7b8xBD
+        gP+1cfE3N0921mTEgl6swV9uN+5mf3anW3j22eu6ySKUprHV8lgwTjv7PlCV
+        ky0gjuAdaHUmoD/wlL3HtOE7Bq3BZgYx/N9zHfIocBoLL4u1fRUVTroDP1T4
+        nCDIJWRpstahF8o99L1foPde0864j8RITcKyXYYrjSFVS6arDnS7xDSNlFoH
+        qVlKNczZHF/rZU+RD74+6uMXoDdnyNQvGsk6TJVZ6bXz8H4PGvhVHDz8Qe+r
+        /qooaHVm8VxqCTOp/u7b6IC/Ms5U0Mc8JcAATNN5iDH5A39rVdY8sLfQrs2B
+        PfQSapF5zbbIz1nocC/Q00i0nEB/wI9KwEZyBM/pb98GBoVXUm18ikK+jAKV
+        Swa22lhydpmjC9eOPB8X/imewHnYK0yYefKJiZf7RWfwxDLPFDh747OhkqPC
+        72GGxkSTM6ZKf596IVkiIfAZjk/kwkvNLKOXTEfC7MlV9jD49Pq/ze9w/s3O
+        D52TrG039xQ6d2WuMNN+vkOGyiZ6A/XD/mt+nSMWBw2wsvoQ/2f90PtTrDFb
+        5g4aKrTwOWgFdZGSCqMa5nem1xvhK0xy0L1rD3OGdqEDu0HqIHezU8PWBeZ1
+        LuMy+A75yp2Kf+0diE2AIYq2wN6Herc/55MfZG1xYPZQfxehtpTz7HaSVbgD
+        rLaEuf+of3+NC8i7G/ZE4Y0j2F+Qi7IOhhx7OvA57ASVFlCrwPo6xPUKGYdh
+        53B/400cA3R435dveV3fmZILAn7UesgdEWEXytPj18s9d/P49fMN+D8AAAD/
+        /wMARcq26zgHAAA=
+    http_version: 
+  recorded_at: Thu, 24 Jan 2019 22:17:34 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_BraintreeClientTokenController/POST_create/without_a_payment_method_id/returns_a_content_type_of_application/json.yml
+++ b/spec/cassettes/Spree_BraintreeClientTokenController/POST_create/without_a_payment_method_id/returns_a_content_type_of_application/json.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.94.0
+      X-Apiversion:
+      - '5'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic eW05ZGp3cXBreGJ2M3h6dDo0Z2hnaGt5cDJ5eTZ5cWM4
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 24 Jan 2019 22:17:33 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Authentication:
+      - server_to_server
+      Braintree-Service-Origin:
+      - clientauth
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"76775b914b2d49f947866d514b8e31cd"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f622f2ab-0c12-4d08-804e-6efb57d04ba8
+      X-Runtime:
+      - '1.634035'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAH05SlwAA3yVy5KbOhCG93mKqdnnBISZE6omSY3tAUNZcoxtQNoZiTFg
+        CXPiC5enPy2cZCYVJws2Qn37++vW45dWybtL9u1YHKpP9+Y/xv1dVvGDKKrd
+        p/vN2n3/8f7L53ePXBZZdXp/Ouyz6vO7u7vHy1aes89ZFyCWBP02ds5+eejm
+        kyAXSXhIraDOlGvo81DJM0NRx2dBnVbLYlEEipXPJvE2LS53NlNsjxE2MSLF
+        wgsVXe87vKYtQcuOlniESz7CKCgWsVvQctPhqW+SnlpUPduLaaTI1Lew2tgv
+        HulY7BosDl9osnRw+dQuVkaDV0ZH3GWHy0NL+kOPu5GJpxCx34wW6+U3PH1q
+        sNvC2VNHlCm5Igca20aC5P5rUhdpGdlZ9WyLqbDSRIzINOBiDTYla0QcHLcx
+        edmiyP6ayNMiDv8TlttsrbwQJRllUC9oUqbIVttYRFw1uv6DmIUN7w+XOYK7
+        K7uHeHuqnNFcBR2N5VnMAslikQsvsmiyP1PknBbl0sCdcwK9y63nwh18yVRw
+        Jol84GtpEEuchLUzcOGUqSdlWmkdxvXcou0ckUuqWM2sqKNJWKdopPOquIL4
+        rov9sv7Xr6IunfgPvsoNMRv3i+LjhXuuncaRjnXmyD0zL7hkE7sAO+hlCHpv
+        TkMMBf5XztXfzD36RVMwD3qxAn+l3+D17oSnG/h2xcuqKSjK89RrZaqE5J3/
+        EJvG0VcQR8kOtDox0B94Kl5j+vCfgNZw5xliRL/nOuRRkTxVYZFauzOtgnwL
+        friKJEOQSyLybGVDL4wHMl32c/Taa945D1SNzCyp20WytAQyrWy67EC3a0zX
+        ybm315rl3CJSzMitXvYcReDrrT5RBXpLgVz7qpGuwzWFl9+yh/MdaBCd0/jj
+        H/S+6e9M49YWniy1ljCT5u++nQ74q9PCBH3cYwYMUAufhhiTP/C3MnXNA3tz
+        69Yc+EMvoRad1/MGRaVIAhnGdk5VKxn0B/yYDO5ojuA7/u3fwKAKa26NjzSR
+        CxqbUjOwscaas+scXbkOtH1aRcd0AvawV4Ryy+wXJp4e5p0jM889ceDsO58N
+        1xxVUQ8zNGaWnjFT+/ulF5ollgCfyfjIrrxchOf0mmmq3J7dZI+Az7D/2/wO
+        9t/vRUlw1LVtZ6HBZ1jnCjMdlVvkmGJiN1B/Q+Pmpx3zJGhAjOWb+D/qh94f
+        U0v4OnfQ0OBVJEErqIvVXDnnYX6f7ctaRYbQHHSv2sOcoW0SwG7QOgy7+QL7
+        GJi3pY4r4D/kq3cq+bl3IDYDhjjaAHtv6t38mE+517WlsdtD/R1Fba3nGXea
+        VXgDvLaGuX+rf3+LC8i7G/ZEFY4p7C/IxVjFQ449H/gcdoLJK6hVEXuVkMsS
+        Ofth58hoHU4CB3R43Zff87q9MzUXDPyYlyF3xJRfGZ8eP1zfuXePH359Af8H
+        AAD//wMALwFvZjgHAAA=
+    http_version: 
+  recorded_at: Thu, 24 Jan 2019 22:17:33 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_BraintreeClientTokenController/POST_create/without_a_payment_method_id/returns_an_http_success.yml
+++ b/spec/cassettes/Spree_BraintreeClientTokenController/POST_create/without_a_payment_method_id/returns_an_http_success.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zbn5yzq9t7wmwx42/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.94.0
+      X-Apiversion:
+      - '5'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic eW05ZGp3cXBreGJ2M3h6dDo0Z2hnaGt5cDJ5eTZ5cWM4
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 24 Jan 2019 22:17:31 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Authentication:
+      - server_to_server
+      Braintree-Service-Origin:
+      - clientauth
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"785ddf29f91bfe4d8ac1b1aec5d2465f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 18bf7d25-cd2e-4928-a581-8c881a22d5eb
+      X-Runtime:
+      - '0.582379'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAHs5SlwAA3yVW3ObOhDH3/spMnnvKQjjU2aSdmITMIwl19jmojcjEQOW
+        MKe+cPn0Z4XTJp26feAFaW///e3q4Wsrxd0l+34sDtXjvf6Pdn+XVezAi2r3
+        eL9ZOx8/33/98uGBiSKrTh9Ph31Wfflwd/dw2Ypz9iXrfERjv99G1tkrD918
+        6uc8Dg6p4deZdDT1P5DiTFHYsZlfp9WyWBReR8tc4t7PFzZr8NqRxA5zsuY5
+        RrRYRLjFkWfSNZzZTo7LPcJRIJM1KRKkbEWJbaZhNxmRaKNjm+bK5sUlHY0c
+        jUbBSxIvLVw+tYuV1uCV1hFn2eHy0JL+0OPVSFvY+x6XXkvs3XdsPzXYacHP
+        U0ekLpgkhyQytRiJ/be4LtIyNLPq2eQ2N9KYj4jtM74Gm5I2PPKP24i8bFFo
+        fovFaREF/3HDabZGXvCSjDKoFzQpU2TKbcRDJhuo3z/wWdCw/nCZI7i7MnuI
+        t0+kNZpLv0siceYzX9CI59wNjSTenxNknRblUsOddQK9y63rwB18yaR/JrEY
+        s7XQiMFP3NhpuLDK1BUirZQOk3puJO0ckUsqaU2NsEvioE7RSOVVMQnxHQd7
+        Zf2vV4VdOvXGnsw1Ppv0i+LzhbmOmUahinVmyDlT179kU7MAO+hlAHpvTkMM
+        Cf5X1tXfzDl6RVNQF3qxAn+lBz3enbC9gW9XvKwa6GOep24rUskF67xxpGtH
+        T0IcKTrQ6kRBf+CpeIvpwTkBreHOM8QIf891yKMieSqDIjV256Ty8y34YTIU
+        FEEuMc+zlQm90MbEXvZz9NZr1lnjRI70LK7bRbw0ONKNzF52oNs1pmPlzN0r
+        zXJmEMFn5FYve4ZC8PVen7ACvQVHjnnVSNXh6NzNb9nD/x1oEJ7T6PMf9L7p
+        75xErcldUSotYSb1331bHfBXp4UO+jjHDBhIDHwaYkz/wN9KVzUP7M2NW3Pg
+        Db2EWlRezxsUljz2RRCZeSJbQaE/4EencEdxBN/xb2cDgzKomTE5JrFYJJEu
+        FAMbY6I4u87RlWtf2adVeEynYA97hUunzH5h4mk87yyRuc6JAWevfDZMcVSF
+        PczQhBpqxnTl75deKJZoDHzGkyO98nLhrtUrphPp9PQmewR8Bv3f5newf70X
+        xv5R1badBRqbYZUrzHRYbpGl86nZQP1NEjU/7agrQAOiLd/F/1E/9P6YGtxT
+        uYOGGqtCAVpBXbRm0joP8/tsXtYy1LjioHvTHuYMbWMfdoPSQe1m/0IlBeZN
+        oeJyOId81U4lP/cOxKbAEEMbYO9dvZsf8yn2qrY0cnqov0tQW6t5xp1iFd4A
+        t61h7t/r39/iAvLuhj1RBZME9hfkoq2iIceeDXwOO0FnFdQqibmKyWWJrP2w
+        c0S4Dqa+BTq87cvXvG7vTMUFBT/6ZcgdUelV2uPDp+s79+Hh068v4P8AAAD/
+        /wMA01dMajgHAAA=
+    http_version: 
+  recorded_at: Thu, 24 Jan 2019 22:17:31 GMT
+recorded_with: VCR 3.0.3

--- a/spec/solidus/gateway/braintree_gateway_spec.rb
+++ b/spec/solidus/gateway/braintree_gateway_spec.rb
@@ -174,6 +174,8 @@ describe Solidus::Gateway::BraintreeGateway, :vcr do
 
           expect(card.gateway_payment_profile_id).to be_present
           expect(card.gateway_customer_profile_id).to be_present
+
+          expect(card.user.braintree_customer_id).to eq card.gateway_customer_profile_id
         end
       end
 
@@ -364,6 +366,8 @@ describe Solidus::Gateway::BraintreeGateway, :vcr do
       let(:nonce){ Braintree::Test::Nonce::PayPalFuturePayment }
 
       before do
+        allow(user).to receive(:braintree_customer_id).and_return(nil)
+
         payment.source.gateway_customer_profile_id = nil
         payment.source.save!
         payment.authorize!


### PR DESCRIPTION
To promote a one to one relationship between braintree customers and
spree users, add the braintree customer id to the spree_users table.
Anytime a new client token is generated for a new payment method, pass
that customer id in as one of the options so that all new payment
methods are added to the same braintree customer associated to the spree
user.