### PR TITLE
Gemfile maintenance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,16 +4,8 @@ branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem "solidus", github: "solidusio/solidus", branch: branch
 gem "solidus_support", github: "solidusio/solidus_support"
 
-if branch == 'master' || branch >= "v2.3"
-  gem "rails", "~> 5.1.0"
-  gem "rails-controller-testing", group: :test
-elsif branch >= "v2.0"
-  gem "rails", "~> 5.0.0"
-  gem "rails-controller-testing", group: :test
-else
-  gem "rails", "~> 4.2.0"
-  gem "rails_test_params_backport", group: :test
-end
+gem "rails", "~> 5.1.0"
+gem "rails-controller-testing", group: :test
 
 case ENV['DB']
 when 'mysql'

--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,9 @@ end
 
 case ENV['DB']
 when 'mysql'
-  gem 'mysql2'
+  gem 'mysql2', '~> 0.4.10'
 when 'postgres'
-  gem 'pg', '< 1.0'
+  gem 'pg', '~> 0.21'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "solidus", github: "solidusio/solidus", branch: branch
 gem "solidus_support", github: "solidusio/solidus_support"
 
 gem "rails", "~> 5.1.0"
-gem "rails-controller-testing", group: :test
+gem 'rails-controller-testing', '~> 1.0', '>= 1.0.4', group: :test
 
 case ENV['DB']
 when 'mysql'
@@ -21,7 +21,7 @@ group :development, :test do
     gem 'factory_bot', '> 4.10.0'
   end
 
-  gem "pry-rails"
+  gem 'pry-rails', '~> 0.3.9'
 end
 
 gemspec


### PR DESCRIPTION
Keeping up with your usual extension maintenance, this PR introduces the following changes:

* Use consistent versioning for DB adapters
* Remove dependencies specific to unsupported Solidus versions
* Add missing pessimistic versioning —see solidusio/solidus_auth_devise#149 and solidusio-contrib/solidus_papertrail#22 for reference