### PR TITLE
Suggest setting a value for environment preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Control Panel.
 
 This gem extends your solidus application by adding a `POST /api/payment_client_token` endpoint to you application to generate Braintree payment client token. This endpoint requires an authentication token in your request header.
 
-It creates a new `PaymentMethod` class called `Solidus::Gateway::BraintreeGateway`. You can configure this payment method in the admin and add your Braintree public/private keys and merchant id. The admin will render a Braintree dropin container when prompting you to create an order payment.
+It creates a new `PaymentMethod` class called `Solidus::Gateway::BraintreeGateway`. You can configure this payment method in the admin and add your Braintree public/private keys, merchant id, and the proper environment. Please ensure that the environment value is included among the values listed [here](https://github.com/braintree/braintree_ruby/blob/7660ae6f6d228acee8eaedd1830afafbaf91820f/lib/braintree/configuration.rb#L235), otherwise you will encounter unexpected errors. The admin will render a Braintree dropin container when prompting you to create an order payment.
 
 It adds a json or text `data` field on `Spree::CreditCard` for storing additional information received from Braintree for addtional payment methods.
 


### PR DESCRIPTION
Leaving environment preference unset or setting it with a wrong value (a wrong value is a value that is not listed [here](https://github.com/braintree/braintree_ruby/blob/7660ae6f6d228acee8eaedd1830afafbaf91820f/lib/braintree/configuration.rb#L235)) leads to unexpected errors, like the following:

```
Errno::ECONNREFUSED (Failed to open TCP connection to :80 (Connection refused - connect(2) for nil port 80)):
  
/home/maurizio/.asdf/installs/ruby/2.6.2/lib/ruby/2.6.0/net/http.rb:949:in `rescue in block in connect'
/home/maurizio/.asdf/installs/ruby/2.6.2/lib/ruby/2.6.0/net/http.rb:946:in `block in connect'
/home/maurizio/.asdf/installs/ruby/2.6.2/lib/ruby/2.6.0/timeout.rb:76:in `timeout'
/home/maurizio/.asdf/installs/ruby/2.6.2/lib/ruby/2.6.0/net/http.rb:945:in `connect'
/home/maurizio/.asdf/installs/ruby/2.6.2/lib/ruby/2.6.0/net/http.rb:930:in `do_start'
/home/maurizio/.asdf/installs/ruby/2.6.2/lib/ruby/2.6.0/net/http.rb:919:in `start'
braintree (2.96.0) lib/braintree/http.rb:111:in `_http_do'
braintree (2.96.0) lib/braintree/http.rb:37:in `post'
braintree (2.96.0) lib/braintree/client_token_gateway.rb:19:in `generate'
/home/maurizio/Sviluppo/Nebulab/solidus_braintree/app/models/solidus/gateway/braintree_gateway.rb:61:in `generate_client_token'
/home/maurizio/Sviluppo/Nebulab/solidus_braintree/app/controllers/spree/api/braintree_client_token_controller.rb:11:in `create'
```