### PR TITLE
Remove credit cards image

### DIFF
--- a/app/views/spree/checkout/payment/_braintree.html.erb
+++ b/app/views/spree/checkout/payment/_braintree.html.erb
@@ -11,7 +11,6 @@
   <div class="braintree-cc-input">
     <div class="braintree-cc-header">
       <%= t('solidus_braintree.creditcard_header_html') %>
-      <%= image_tag 'credit_cards/credit_card.gif', :id => 'credit-card-image' %>
     </div>
     <% param_prefix = "payment_source[#{payment_method.id}]" %>
 


### PR DESCRIPTION
The coming soon alternative/replacement of solidus frontend,
solidus_starter_frontend, will not provide this image in its assets.
Furthermore, this is a low res image that most of the time gets deleted since the early stages of customization.