### PR TITLE
Make migrations independent of existing models

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,3 +73,7 @@ RSpec/MultipleMemoizedHelpers:
     - spec/models/solidus_paypal_braintree/gateway_spec.rb
     - spec/controllers/solidus_paypal_braintree/client_tokens_controller_spec.rb
     - spec/features/frontend/braintree_credit_card_checkout_spec.rb
+
+Rails/ApplicationRecord:
+  Exclude:
+    - db/migrate/*

--- a/db/migrate/20170508085402_add_not_null_constraint_to_sources_payment_type.rb
+++ b/db/migrate/20170508085402_add_not_null_constraint_to_sources_payment_type.rb
@@ -1,8 +1,11 @@
 class AddNotNullConstraintToSourcesPaymentType < SolidusSupport::Migration[4.2]
+  class SolidusPaypalBraintreeSource < ActiveRecord::Base
+  end
+
   def change
     reversible do |dir|
       dir.up do
-        SolidusPaypalBraintree::Source.where(payment_type: nil).
+        SolidusPaypalBraintreeSource.where(payment_type: nil).
           update_all(payment_type: 'CreditCard')
       end
     end


### PR DESCRIPTION
## Summary

Using model classes local to the migration is a technique that allows accessing the underlying tables through AR without a dependency of the app models being available across time. This is supported by rails that explicitly sets the table_name_prefix of migration classes to be an empty string. 

In this specific case, for example, `SpreePayment.table_name` will be `spree_payments`, which is the same as `Spree::Payment.table_name`.

If Spree::Payment will change name and become, say, Solidus::Payment, this migration won't break a sweat and will keep working.

This way any change in table names or prefixes, or even removing a model altogether won't affect older migrations.

## Manual check log

```
solidus_braintree:elia/table-prefix-independent-migrations * ⤑ bin/rails-sandbox db:rollback                                                                                                ~/C/N/solidus_braintree
== 20230119102399 AddVenmoToBraintreeConfiguration: reverting =================
-- remove_column(:solidus_paypal_braintree_configurations, :venmo, :boolean, {:null=>false, :default=>false})
   -> 0.0055s
== 20230119102399 AddVenmoToBraintreeConfiguration: reverted (0.0055s) ========

solidus_braintree:elia/table-prefix-independent-migrations + ⤑ bin/rails-sandbox db:rollback                                                                                                ~/C/N/solidus_braintree
== 20230119102398 AddPaypalFundingSourceToSolidusPaypalBraintreeSources: reverting 
-- remove_column(:solidus_paypal_braintree_sources, :paypal_funding_source, :integer)
   -> 0.0073s
== 20230119102398 AddPaypalFundingSourceToSolidusPaypalBraintreeSources: reverted (0.0073s) 

solidus_braintree:elia/table-prefix-independent-migrations + ⤑ bin/rails-sandbox db:rollback                                                                                                ~/C/N/solidus_braintree
== 20230119102397 Add3dSecureToBraintreeConfiguration: reverting ==============
-- remove_column(:solidus_paypal_braintree_configurations, :three_d_secure, :boolean, {:null=>false, :default=>false})
   -> 0.0054s
== 20230119102397 Add3dSecureToBraintreeConfiguration: reverted (0.0055s) =====

solidus_braintree:elia/table-prefix-independent-migrations + ⤑ bin/rails-sandbox db:rollback                                                                                                ~/C/N/solidus_braintree
== 20230119102396 AddPaypalButtonPreferencesToBraintreeConfigurations: reverting 
-- remove_column(:solidus_paypal_braintree_configurations, :preferences, :text)
   -> 0.0051s
== 20230119102396 AddPaypalButtonPreferencesToBraintreeConfigurations: reverted (0.0052s) 

solidus_braintree:elia/table-prefix-independent-migrations + ⤑ bin/rails-sandbox db:rollback                                                                                                ~/C/N/solidus_braintree
== 20230119102395 AddNotNullConstraintToSourcesPaymentType: reverting =========
-- change_column_null(:solidus_paypal_braintree_sources, :payment_type, true)
   -> 0.0074s
== 20230119102395 AddNotNullConstraintToSourcesPaymentType: reverted (0.0075s) 

solidus_braintree:elia/table-prefix-independent-migrations + ⤑ bin/rails-sandbox db:rollback                                                                                                ~/C/N/solidus_braintree
== 20230119102394 AddNullConstraintToSources: reverting =======================
-- change_column_null(:solidus_paypal_braintree_sources, :payment_method_id, true)
   -> 0.0078s
== 20230119102394 AddNullConstraintToSources: reverted (0.0078s) ==============

solidus_braintree:elia/table-prefix-independent-migrations + ⤑ bin/rails-sandbox db:migrate                                                                                                 ~/C/N/solidus_braintree
== 20230119102394 AddNullConstraintToSources: migrating =======================
-- change_column_null(:solidus_paypal_braintree_sources, :payment_method_id, false)
   -> 0.0066s
== 20230119102394 AddNullConstraintToSources: migrated (0.0090s) ==============

== 20230119102395 AddNotNullConstraintToSourcesPaymentType: migrating =========
-- change_column_null(:solidus_paypal_braintree_sources, :payment_type, false)
   -> 0.0067s
== 20230119102395 AddNotNullConstraintToSourcesPaymentType: migrated (0.0088s) 

== 20230119102396 AddPaypalButtonPreferencesToBraintreeConfigurations: migrating 
-- add_column(:solidus_paypal_braintree_configurations, :preferences, :text)
   -> 0.0014s
== 20230119102396 AddPaypalButtonPreferencesToBraintreeConfigurations: migrated (0.0014s) 

== 20230119102397 Add3dSecureToBraintreeConfiguration: migrating ==============
-- add_column(:solidus_paypal_braintree_configurations, :three_d_secure, :boolean, {:null=>false, :default=>false})
   -> 0.0014s
== 20230119102397 Add3dSecureToBraintreeConfiguration: migrated (0.0014s) =====

== 20230119102398 AddPaypalFundingSourceToSolidusPaypalBraintreeSources: migrating 
-- add_column(:solidus_paypal_braintree_sources, :paypal_funding_source, :integer)
   -> 0.0013s
== 20230119102398 AddPaypalFundingSourceToSolidusPaypalBraintreeSources: migrated (0.0013s) 

== 20230119102399 AddVenmoToBraintreeConfiguration: migrating =================
-- add_column(:solidus_paypal_braintree_configurations, :venmo, :boolean, {:null=>false, :default=>false})
   -> 0.0013s
== 20230119102399 AddVenmoToBraintreeConfiguration: migrated (0.0014s) ========

solidus_braintree:elia/table-prefix-independent-migrations + ⤑                                                                                                                              ~/C/N/solidus_braintree
```
<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if yuou do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
