### PR TITLE
add device-data-collection

### DIFF
--- a/app/assets/javascripts/solidus_braintree/checkout.js
+++ b/app/assets/javascripts/solidus_braintree/checkout.js
@@ -42,7 +42,7 @@ $(function() {
 
       if ($field.is(":visible") && !$field.data("submitting")) {
         var $nonce = $("#payment_method_nonce", $field);
-
+        var $deviceData = $("#device_data", $field);
         if ($nonce.length > 0 && $nonce.val() === "") {
           var client = braintreeForm._merchantConfigurationOptions._solidusClient;
 
@@ -56,6 +56,10 @@ $(function() {
             }
 
             $nonce.val(payload.nonce);
+            
+            if (typeof(IS_FRONTEND) !== 'undefined') {
+              $deviceData.val(client._dataCollectorInstance.deviceData);
+            }
 
             if (!client.useThreeDSecure) {
               $paymentForm.submit();

--- a/app/assets/javascripts/solidus_braintree/frontend.js
+++ b/app/assets/javascripts/solidus_braintree/frontend.js
@@ -12,3 +12,6 @@
 //= require solidus_braintree/paypal_messaging
 //= require solidus_braintree/apple_pay_button
 //= require solidus_braintree/venmo_button
+
+
+const IS_FRONTEND = true;

--- a/app/assets/javascripts/solidus_braintree/hosted_form.js
+++ b/app/assets/javascripts/solidus_braintree/hosted_form.js
@@ -7,6 +7,7 @@ SolidusBraintree.HostedForm.prototype.initialize = function() {
   this.client = SolidusBraintree.createClient({
     paymentMethodId: this.paymentMethodId,
     useThreeDSecure: (typeof(window.threeDSecureOptions) !== 'undefined'),
+    useDataCollector: (typeof(IS_FRONTEND) !== 'undefined'),
   });
 
   return this.client.initialize().

--- a/app/models/solidus_braintree/gateway.rb
+++ b/app/models/solidus_braintree/gateway.rb
@@ -364,6 +364,10 @@ module SolidusBraintree
         params[:payment_method_nonce] = source.nonce
       end
 
+      if source.try(:device_data)
+        params[:device_data] = source.device_data
+      end
+
       if source.paypal?
         params[:shipping] = braintree_shipping_address(options)
       end

--- a/app/views/spree/shared/_braintree_hosted_fields.html.erb
+++ b/app/views/spree/shared/_braintree_hosted_fields.html.erb
@@ -31,6 +31,7 @@
   <div class="clear"></div>
   <input type="hidden" name="<%= prefix %>[payment_type]" value="<%= SolidusBraintree::Source::CREDIT_CARD %>">
   <input type="hidden" id="payment_method_nonce" name="<%= prefix %>[nonce]">
+  <input type="hidden" id="device_data" name="<%= prefix %>[device_data]">
 </div>
 
 

--- a/db/migrate/20230210104310_add_device_data_to_braintree_sources.rb
+++ b/db/migrate/20230210104310_add_device_data_to_braintree_sources.rb
@@ -1,0 +1,5 @@
+class AddDeviceDataToBraintreeSources < ActiveRecord::Migration[5.1]
+  def change
+    add_column :solidus_paypal_braintree_sources, :device_data, :string
+  end
+end

--- a/lib/solidus_braintree/engine.rb
+++ b/lib/solidus_braintree/engine.rb
@@ -18,7 +18,7 @@ module SolidusBraintree
       config.to_prepare do
         app.config.spree.payment_methods << SolidusBraintree::Gateway
         SolidusBraintree::Gateway.allowed_admin_form_preference_types.push(:preference_select).uniq!
-        ::Spree::PermittedAttributes.source_attributes.concat([:nonce, :payment_type, :paypal_funding_source]).uniq!
+        ::Spree::PermittedAttributes.source_attributes.concat([:nonce, :payment_type, :paypal_funding_source, :device_data]).uniq!
       end
     end
 

--- a/spec/models/solidus_braintree/gateway_spec.rb
+++ b/spec/models/solidus_braintree/gateway_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe SolidusBraintree::Gateway do
       nonce: 'fake-valid-nonce',
       user: user,
       payment_type: payment_type,
-      payment_method: gateway
+      payment_method: gateway,
+      device_data: 'fake-device-data'
     )
   end
 
@@ -219,6 +220,36 @@ RSpec.describe SolidusBraintree::Gateway do
         it 'authorizes the transaction', aggregate_failures: true do
           expect(authorize.message).to eq 'authorized'
           expect(authorize.authorization).to be_present
+        end
+
+        context 'with available device_data' do
+          it 'passes "fake-device-data" as the device_data parameter in the request' do
+            expect_any_instance_of(Braintree::TransactionGateway).
+              to receive(:sale).
+              with(hash_including({ device_data: "fake-device-data" })).and_call_original
+            authorize
+          end
+        end
+
+        context 'without device_data' do
+          let(:source) do
+            SolidusBraintree::Source.create!(
+              nonce: 'fake-valid-nonce',
+              user: user,
+              payment_type: payment_type,
+              payment_method: gateway
+            )
+          end
+
+          before do
+            allow_any_instance_of(Braintree::TransactionGateway).to receive(:sale).and_call_original
+          end
+
+          it 'does not pass "fake-device-data" as the device_data parameter in the request' do
+            expect_any_instance_of(Braintree::TransactionGateway).to_not receive(:sale).with(hash_including({ device_data: "" }))
+
+            authorize
+          end
         end
       end
 


### PR DESCRIPTION
## Summary

Closes https://github.com/solidusio/solidus_braintree/issues/115.

This PR adds device data collection.

The device_data parameter will come in this format
{"correlation_id":"SOME_HASH_VALUE"}

See: https://developer.paypal.com/braintree/docs/guides/premium-fraud-management-tools/device-data-collection

## Question
I don't know if the migration to store the device data is needed as the data doesn't provide any useful application. 
