### PR TITLE
Add Response to log entry permitted classes

### DIFF
--- a/lib/solidus_braintree/engine.rb
+++ b/lib/solidus_braintree/engine.rb
@@ -22,6 +22,12 @@ module SolidusBraintree
       end
     end
 
+    initializer 'add_solidus_braintree_response_to_log_entry_permitted_classes' do
+      Spree.config do |config|
+        config.log_entry_permitted_classes << 'SolidusBraintree::Response'
+      end
+    end
+
     config.assets.precompile += [
       'spree/frontend/solidus_braintree/checkout.js',
       'solidus_braintree_manifest.js'


### PR DESCRIPTION
## Summary

Fixes https://github.com/solidusio/solidus_braintree/issues/108.

`SolidusBraintree::Response` is a direct subclass of `ActiveMerchant::Billing::Response`, which is a core permitted class of `Spree:LogEntry`([1][1]). Furthermore, `SolidusBraintree::Response` doesn't have any additional attributes. Thus, it should be safe to log.

As recommended by the Spree::LogEntry::DisallowedClass error message ([2][2]),
we're adding SolidusBraintree::Response to `log_entry_permitted_classes` through an initializer.

[1]: https://github.com/solidusio/solidus/blob/0c52edfbb0c30ad16b3cf11a3a30ce42fb0dbe70/core/app/models/spree/log_entry.rb#L12
[2]: https://github.com/solidusio/solidus/blob/0c52edfbb0c30ad16b3cf11a3a30ce42fb0dbe70/core/app/models/spree/log_entry.rb#L33

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
