### PR TITLE
Deep stringify the keys of the result params

### DIFF
--- a/app/models/solidus_braintree/response.rb
+++ b/app/models/solidus_braintree/response.rb
@@ -29,7 +29,7 @@ module SolidusBraintree
           # For error responses we want to have the CVV code
           cvv_result: transaction&.cvv_response_code
         )
-        new(false, error_message(result), result.params, options)
+        new(false, error_message(result), result.params.deep_stringify_keys, options)
       end
 
       def response_options(transaction)


### PR DESCRIPTION
Fixes https://github.com/solidusio/solidus_braintree/issues/110.

Summary
--------

A error Braintree response would raise the following error:

```
Spree::LogEntry::DisallowedClass:
  Tried to dump unspecified class: Symbol

  You can specify custom classes to be loaded in config/initializers/spree.rb. E.g:

  Spree.config do |config|
    config.log_entry_permitted_classes = ['MyClass']
  end
```

Solidus Version:
--------

3.4.0.dev

Cause
--------

When `SolidusBraintree::Response.build(result)` accepts an error result, the `result.params` it passes to the new response has symbol keys. Here's a sample of the `result.params`:

```
    {:transaction=>
      {:amount=>"20.00",
       :order_id=>"R300000001",
       :channel=>"Solidus",
       :options=>{:store_in_vault_on_success=>"true"},
       :payment_method_token=>"0ev7m4dt",
       :customer_id=>"180763858",
       :type=>"sale"}}
```

Demonstration
--------

See
https://github.com/solidusio/solidus_braintree/tree/gsmendoza/110-log-entry-disallowed-class-demo for a demonstration of the error and my attempts to fix it. Start from the "Try enabling venmo specs" commit.

Additional context
--------

Related to https://github.com/solidusio/solidus_braintree/issues/108.

There is also a PR in Solidus that will temporarily allow bad payloads  to be saved in payment log entries. See
https://github.com/solidusio/solidus/pull/4953

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
