### PR TITLE
Add device data collection

### DIFF
--- a/app/models/solidus_braintree/gateway.rb
+++ b/app/models/solidus_braintree/gateway.rb
@@ -364,6 +364,10 @@ module SolidusBraintree
         params[:payment_method_nonce] = source.nonce
       end
 
+      if source&.device_data
+        params[:device_data] = source.device_data
+      end
+
       if source.paypal?
         params[:shipping] = braintree_shipping_address(options)
       end

--- a/db/migrate/20230210104310_add_device_data_to_braintree_sources.rb
+++ b/db/migrate/20230210104310_add_device_data_to_braintree_sources.rb
@@ -1,0 +1,5 @@
+class AddDeviceDataToBraintreeSources < ActiveRecord::Migration[5.1]
+  def change
+    add_column :solidus_paypal_braintree_sources, :device_data, :string
+  end
+end

--- a/lib/generators/solidus_braintree/install/templates/app/assets/javascripts/spree/frontend/solidus_braintree/checkout.js
+++ b/lib/generators/solidus_braintree/install/templates/app/assets/javascripts/spree/frontend/solidus_braintree/checkout.js
@@ -42,7 +42,7 @@ $(function() {
 
       if ($field.is(":visible") && $field.is(":enabled") && !$field.data("submitting")) {
         var $nonce = $("#payment_method_nonce", $field);
-
+        var $deviceData = $("#device_data", $field);
         if ($nonce.length > 0 && $nonce.val() === "") {
           var client = braintreeForm._merchantConfigurationOptions._solidusClient;
 
@@ -56,6 +56,8 @@ $(function() {
             }
 
             $nonce.val(payload.nonce);
+            
+            $deviceData.val(client._dataCollectorInstance.deviceData);
 
             if (!client.useThreeDSecure) {
               $paymentForm.submit();

--- a/lib/generators/solidus_braintree/install/templates/app/assets/javascripts/spree/frontend/solidus_braintree/hosted_form.js
+++ b/lib/generators/solidus_braintree/install/templates/app/assets/javascripts/spree/frontend/solidus_braintree/hosted_form.js
@@ -7,6 +7,7 @@ SolidusBraintree.HostedForm.prototype.initialize = function() {
   this.client = SolidusBraintree.createClient({
     paymentMethodId: this.paymentMethodId,
     useThreeDSecure: (typeof(window.threeDSecureOptions) !== 'undefined'),
+    useDataCollector: true,
   });
 
   return this.client.initialize().

--- a/lib/generators/solidus_braintree/install/templates/app/views/spree/shared/_braintree_hosted_fields.html.erb
+++ b/lib/generators/solidus_braintree/install/templates/app/views/spree/shared/_braintree_hosted_fields.html.erb
@@ -27,6 +27,7 @@
   <div class="clear"></div>
   <input type="hidden" name="<%= prefix %>[payment_type]" value="<%= SolidusBraintree::Source::CREDIT_CARD %>">
   <input type="hidden" id="payment_method_nonce" name="<%= prefix %>[nonce]">
+  <input type="hidden" id="device_data" name="<%= prefix %>[device_data]">
 </div>
 
 

--- a/lib/solidus_braintree/engine.rb
+++ b/lib/solidus_braintree/engine.rb
@@ -18,7 +18,10 @@ module SolidusBraintree
       config.to_prepare do
         app.config.spree.payment_methods << SolidusBraintree::Gateway
         SolidusBraintree::Gateway.allowed_admin_form_preference_types.push(:preference_select).uniq!
-        ::Spree::PermittedAttributes.source_attributes.concat([:nonce, :payment_type, :paypal_funding_source]).uniq!
+
+        ::Spree::PermittedAttributes.source_attributes.concat(
+          [:nonce, :payment_type, :paypal_funding_source, :device_data]
+        ).uniq!
       end
     end
 


### PR DESCRIPTION
Closes https://github.com/solidusio/solidus_braintree/issues/115.

Revision of https://github.com/solidusio/solidus_braintree/pull/103.

This commit adds device data collection.

See: https://developer.paypal.com/braintree/docs/guides/premium-fraud-management-tools/device-data-collection

## Testing

Confirmed after checking out with Braintree Credit Card payment method:

![image](https://user-images.githubusercontent.com/61476/222333167-5be2ac29-ce6d-4255-b350-493b772cf4cf.png)

![image](https://user-images.githubusercontent.com/61476/222333284-2def8e52-12b9-4061-9f2b-909c41743962.png)


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
