### PR TITLE
Migrate database by default

### DIFF
--- a/lib/generators/solidus_braintree/install/install_generator.rb
+++ b/lib/generators/solidus_braintree/install/install_generator.rb
@@ -7,7 +7,7 @@ module SolidusBraintree
     class InstallGenerator < Rails::Generators::AppBase
       argument :app_path, type: :string, default: Rails.root
 
-      class_option :migrate, type: :boolean, default: false
+      class_option :migrate, type: :boolean, default: true
       class_option :backend, type: :boolean, default: true
       class_option :frontend, type: :string, default: 'starter'
 


### PR DESCRIPTION
We need to migrate the database by default so that once we add Braintree to the Solidus installer, running `solidus:install` would automatically run the SolidusBraintree migrations. See https://github.com/solidusio/solidus/issues/4749.

This should be safe since migrate is also enabled by default in SolidusPaypalCommercePlatform. See
https://github.com/solidusio/solidus_paypal_commerce_platform/blob/a6f87f5d6a1621eda453db31ccdc8c3903ef48c4/lib/generators/solidus_paypal_commerce_platform/install/install_generator.rb#L6.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
