### PR TITLE
Fix: deprecated version in warning should be 1.x instead of 0.x

### DIFF
--- a/lib/generators/solidus_braintree/install/install_generator.rb
+++ b/lib/generators/solidus_braintree/install/install_generator.rb
@@ -139,7 +139,7 @@ module SolidusBraintree
       def alert_no_classic_frontend_support
         support_code_for(:classic_frontend) do
           message = <<~TEXT
-            For solidus_frontend compatibility, please use the deprecated version 0.x.
+            For solidus_frontend compatibility, please use the deprecated version 1.x.
             The new version of this extension only supports Solidus Starter Frontend.
             No frontend code has been copied to your application.
           TEXT


### PR DESCRIPTION
## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
