### PR TITLE
Add device data to PayPal checkout

### DIFF
--- a/app/models/solidus_braintree/transaction.rb
+++ b/app/models/solidus_braintree/transaction.rb
@@ -6,7 +6,7 @@ module SolidusBraintree
   class Transaction
     include ActiveModel::Model
 
-    attr_accessor :nonce, :payment_method, :payment_type, :paypal_funding_source, :address, :email, :phone
+    attr_accessor :nonce, :payment_method, :payment_type, :paypal_funding_source, :address, :email, :phone, :device_data
 
     validates :nonce, presence: true
     validates :payment_method, presence: true

--- a/app/models/solidus_braintree/transaction_import.rb
+++ b/app/models/solidus_braintree/transaction_import.rb
@@ -32,6 +32,7 @@ module SolidusBraintree
         payment_type: transaction.payment_type,
         payment_method: transaction.payment_method,
         paypal_funding_source: transaction.paypal_funding_source,
+        device_data: transaction.device_data,
         user: user
       )
     end

--- a/lib/generators/solidus_braintree/install/templates/app/assets/javascripts/spree/frontend/solidus_braintree/paypal_button.js
+++ b/lib/generators/solidus_braintree/install/templates/app/assets/javascripts/spree/frontend/solidus_braintree/paypal_button.js
@@ -144,7 +144,8 @@ SolidusBraintree.PaypalButton.prototype._transactionParams = function(payload) {
       "nonce" : payload.nonce,
       "payment_type" : payload.type,
       "paypal_funding_source": SolidusBraintree.fundingSource,
-      "address_attributes" : this._addressParams(payload)
+      "address_attributes" : this._addressParams(payload),
+      "device_data": this._client._dataCollectorInstance.deviceData
     }
   };
 };

--- a/lib/generators/solidus_braintree/install/templates/app/controllers/solidus_braintree/transactions_controller.rb
+++ b/lib/generators/solidus_braintree/install/templates/app/controllers/solidus_braintree/transactions_controller.rb
@@ -13,7 +13,8 @@ module SolidusBraintree
       { address_attributes: [
         :country_code, :country_name, :name, :city, :zip, :state_code,
         :address_line_1, :address_line_2, :first_name, :last_name
-      ] }
+      ] },
+      :device_data
     ].freeze
 
     def create

--- a/lib/generators/solidus_braintree/install/templates/app/views/spree/shared/_paypal_checkout_button.html.erb
+++ b/lib/generators/solidus_braintree/install/templates/app/views/spree/shared/_paypal_checkout_button.html.erb
@@ -15,6 +15,7 @@
     shippingAddressEditable: false,
     environment: '<%= Rails.env.production? ? "production" : "sandbox" %>',
     locale: '<%= paypal_button_preference(:paypal_button_locale, store: current_store) %>',
+    useDataCollector: <%= SolidusBraintree::Gateway.first.preferred_use_data_collector %>,
     style: {
       color: '<%= paypal_button_preference(:paypal_button_color, store: current_store) %>',
       shape: '<%= paypal_button_preference(:paypal_button_shape, store: current_store) %>',


### PR DESCRIPTION
Closes #120 

Please note that at the moment there's no way to see the information about device data in Braintree for PayPal orders. They still recommend to send those information though, so that's what we are doing here.