### PR TITLE
Fix: user should still be able to disable data collection in a SolidusBraintree hosted form

### DIFF
--- a/app/models/solidus_braintree/source.rb
+++ b/app/models/solidus_braintree/source.rb
@@ -25,6 +25,7 @@ module SolidusBraintree
 
     validates :payment_type, inclusion: [PAYPAL, APPLE_PAY, VENMO, CREDIT_CARD]
 
+    before_validation :clear_device_data_if_blank
     before_save :clear_paypal_funding_source, unless: :paypal?
 
     scope(:with_payment_profile, -> { joins(:customer) })
@@ -126,6 +127,10 @@ module SolidusBraintree
 
     def braintree_client
       @braintree_client ||= payment_method.try(:braintree)
+    end
+
+    def clear_device_data_if_blank
+      self.device_data = nil if device_data.blank?
     end
 
     def clear_paypal_funding_source

--- a/lib/generators/solidus_braintree/install/templates/app/assets/javascripts/spree/frontend/solidus_braintree/checkout.js
+++ b/lib/generators/solidus_braintree/install/templates/app/assets/javascripts/spree/frontend/solidus_braintree/checkout.js
@@ -57,7 +57,9 @@ $(function() {
 
             $nonce.val(payload.nonce);
             
-            $deviceData.val(client._dataCollectorInstance.deviceData);
+            if (client._dataCollectorInstance) {
+              $deviceData.val(client._dataCollectorInstance.deviceData);
+            }
 
             if (!client.useThreeDSecure) {
               $paymentForm.submit();
@@ -95,8 +97,9 @@ $(function() {
     var fieldPromises = $hostedFields.map(function(index, field) {
       var $this = $(this);
       var id = $this.data("id");
+      var useDataCollector = $this.data("use-data-collector");
 
-      var braintreeForm = new SolidusBraintree.createHostedForm(id);
+      var braintreeForm = new SolidusBraintree.createHostedForm(id, useDataCollector);
 
       var formInitializationSuccess = function(formObject) {
         addFormHook(formObject, field);

--- a/lib/generators/solidus_braintree/install/templates/app/assets/javascripts/spree/frontend/solidus_braintree/hosted_form.js
+++ b/lib/generators/solidus_braintree/install/templates/app/assets/javascripts/spree/frontend/solidus_braintree/hosted_form.js
@@ -1,5 +1,6 @@
-SolidusBraintree.HostedForm = function(paymentMethodId) {
+SolidusBraintree.HostedForm = function(paymentMethodId, useDataCollector) {
   this.paymentMethodId = paymentMethodId;
+  this.useDataCollector = useDataCollector;
   this.client = null;
 };
 
@@ -7,7 +8,7 @@ SolidusBraintree.HostedForm.prototype.initialize = function() {
   this.client = SolidusBraintree.createClient({
     paymentMethodId: this.paymentMethodId,
     useThreeDSecure: (typeof(window.threeDSecureOptions) !== 'undefined'),
-    useDataCollector: true,
+    useDataCollector: this.useDataCollector,
   });
 
   return this.client.initialize().

--- a/lib/generators/solidus_braintree/install/templates/app/views/checkouts/payment/_braintree.html.erb
+++ b/lib/generators/solidus_braintree/install/templates/app/views/checkouts/payment/_braintree.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <% if current_store.braintree_configuration.credit_card? %>
-  <fieldset class="braintree-hosted-fields" data-braintree-hosted-fields data-id="<%= id %>">
+  <fieldset class="braintree-hosted-fields" data-braintree-hosted-fields data-id="<%= id %>" data-use-data-collector="<%= SolidusBraintree::Gateway.first.preferred_use_data_collector %>">
     <%= render "spree/shared/braintree_hosted_fields", payment_method: payment_method %>
   </fieldset>
 <% end %>

--- a/spec/models/solidus_braintree/source_spec.rb
+++ b/spec/models/solidus_braintree/source_spec.rb
@@ -537,4 +537,19 @@ RSpec.describe SolidusBraintree::Source, type: :model do
       it { is_expected.to be_falsy }
     end
   end
+
+  describe "#device_data" do
+    let(:payment_source) { build(:solidus_braintree_source) }
+
+    context "when blank on validation" do
+      before do
+        payment_source.device_data = ""
+        payment_source.valid?
+      end
+
+      it "is set to nil" do
+        expect(payment_source.device_data).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/solidusio/solidus_braintree/issues/126.

## Walkthrough and demo

See https://youtu.be/IAo6ZDg5kdY.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
