### PR TITLE
Adapt to latest Solidus release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ commands:
             sudo apt-get update
             sudo apt-get install -yq libvips-dev
       - solidusio_extensions/test-branch:
-          branch: master
+          branch: main
           command: |
             export FRONTEND=starter
             sudo gem update --system
@@ -66,14 +66,14 @@ workflows:
       - run-specs-with-sqlite
       - lint-code
 
-  "Weekly run specs against master":
+  "Weekly run specs against main":
     triggers:
       - schedule:
           cron: "0 0 * * 4" # every Thursday
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - run-specs-with-postgres
       - run-specs-with-mysql

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,11 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
+branch = ENV.fetch('SOLIDUS_BRANCH', 'main')
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
 # The solidus_frontend gem has been pulled out since v3.2
-gem 'solidus_frontend', github: 'solidusio/solidus_frontend' if branch == 'master'
+gem 'solidus_frontend', github: 'solidusio/solidus_frontend' if branch == 'main'
 gem 'solidus_frontend' if branch >= 'v3.2' # rubocop:disable Bundler/DuplicatedGem
 
 # Needed to help Bundler figure out how to resolve dependencies,

--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 branch = ENV.fetch('SOLIDUS_BRANCH', 'main')
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
-# The solidus_frontend gem has been pulled out since v3.2
-gem 'solidus_frontend', github: 'solidusio/solidus_frontend' if branch == 'main'
-gem 'solidus_frontend' if branch >= 'v3.2' # rubocop:disable Bundler/DuplicatedGem
-
 # Needed to help Bundler figure out how to resolve dependencies,
 # otherwise it takes forever to resolve them.
 # See https://github.com/bundler/bundler/issues/6677

--- a/bin/dummy-app
+++ b/bin/dummy-app
@@ -28,7 +28,7 @@ if [ ! -d "dummy-app" ]; then
 fi
 
 cd ./dummy-app
-unbundled bundle add solidus --github solidusio/solidus --branch "${BRANCH:-master}" --version '> 0.a'
+unbundled bundle add solidus --github solidusio/solidus --branch "${BRANCH:-main}" --version '> 0.a'
 unbundled bundle exec rake db:drop db:create
 unbundled bundle exec rails generate solidus:install --auto-accept --payment-method=none --no-seed --no-sample "$@"
 unbundled bundle add $extension_name --path ..

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -22,7 +22,7 @@ if [ ! -z $SOLIDUS_BRANCH ]
 then
   BRANCH=$SOLIDUS_BRANCH
 else
-  BRANCH="master"
+  BRANCH="main"
 fi
 
 extension_name="solidus_braintree"
@@ -47,7 +47,7 @@ if [ ! -d "sandbox" ]; then
 fi
 
 cd ./sandbox
-unbundled bundle add solidus --github solidusio/solidus --branch "${BRANCH:-master}" --version '> 0.a'
+unbundled bundle add solidus --github solidusio/solidus --branch "${BRANCH:-main}" --version '> 0.a'
 unbundled bundle exec rake db:drop db:create
 unbundled bundle exec rails generate solidus:install --payment-method=none --auto-accept "$@"
 unbundled bundle add ${extension_name} --path '../'

--- a/spec/support/solidus_braintree/order_ready_for_payment.rb
+++ b/spec/support/solidus_braintree/order_ready_for_payment.rb
@@ -21,7 +21,7 @@ RSpec.shared_context 'when order is ready for payment' do
 
   let(:order) do
     order = Spree::Order.create!(
-      line_items: [create(:line_item, price: 50)],
+      line_items: create_list(:line_item, 1, price: 50),
       email: 'test@example.com',
       bill_address: address,
       ship_address: address,


### PR DESCRIPTION
## Summary

Solidus v4 no longer contains solidus_frontend, but this extension is not using it anymore.

Plus, we adapt to the new Solidus default branch. Ref. https://github.com/solidusio/solidus/pull/5042

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
