### PR TITLE
Bump minimal Ruby version requirement to v3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,26 +33,28 @@ jobs:
   run-specs-with-postgres:
     executor:
       name: solidusio_extensions/postgres
-      ruby_version: '3.1'
+      ruby_version: '3.2'
     steps:
       - test-with-starter-frontend
 
   run-specs-with-mysql:
     executor:
       name: solidusio_extensions/mysql
-      ruby_version: '3.0'
+      ruby_version: '3.1'
     steps:
       - test-with-starter-frontend
 
   run-specs-with-sqlite:
     executor:
       name: solidusio_extensions/sqlite
-      ruby_version: '2.7'
+      ruby_version: '3.0'
     steps:
       - test-with-starter-frontend
 
   lint-code:
-    executor: solidusio_extensions/sqlite-memory
+    executor:
+      name: solidusio_extensions/sqlite-memory
+      ruby_version: '3.0'
     steps:
       - solidusio_extensions/lint-code
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
 
 AllCops:
   NewCops: disable
-  TargetRubyVersion: '2.7'
+  TargetRubyVersion: '3.0'
   Exclude:
     - sandbox/**/*
     - dummy-app/**/*

--- a/app/models/solidus_braintree/gateway.rb
+++ b/app/models/solidus_braintree/gateway.rb
@@ -10,7 +10,7 @@ module SolidusBraintree
     class TokenGenerationDisabledError < StandardError; end
 
     # Error message from Braintree that gets returned by a non voidable transaction
-    NON_VOIDABLE_STATUS_ERROR_REGEXP = /can only be voided if status is authorized/.freeze
+    NON_VOIDABLE_STATUS_ERROR_REGEXP = /can only be voided if status is authorized/
 
     TOKEN_GENERATION_DISABLED_MESSAGE = 'Token generation is disabled. ' \
                                         'To re-enable set the `token_generation_enabled` preference on the ' \

--- a/solidus_braintree.gemspec
+++ b/solidus_braintree.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/solidusio/solidus_braintree'
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio/solidus_braintree/blob/master/CHANGELOG.md'
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.7', '< 4')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.0', '< 4')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
## Summary

Ruby [v2.7 reached EOL](https://www.ruby-lang.org/en/downloads/branches/) on 2023-03-31.

This also fixes testing against Solidus master, which also dropped Ruby 2.7 support. See https://github.com/solidusio/solidus/pull/5012.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
