### PR TITLE
Read Capybara javascript_driver from CAPYBARA_JS_DRIVER

### DIFF
--- a/spec/support/solidus_braintree/capybara.rb
+++ b/spec/support/solidus_braintree/capybara.rb
@@ -4,4 +4,4 @@ RSpec.configure do |config|
   end
 end
 
-Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
+Capybara.javascript_driver = (ENV['CAPYBARA_JS_DRIVER'] || :selenium_chrome_headless).to_sym


### PR DESCRIPTION
## Summary

Updates env variable config to be aligned with [similar config in Solidus Starter Frontend](https://github.com/solidusio/solidus_starter_frontend/blob/362c1500cf1319153656629f8ceb4f4d9e90b531/templates/spec/support/solidus_starter_frontend/capybara.rb#L17).

This is helpful because setting `CAPYBARA_JS_DRIVER=selenium_chrome_headless_docker_friendly` will allow tests to run with a Docker-friendly Chrome config, while keeping the default `rack_test` driver for non-JS tests.

Without this change, `CAPYBARA_DRIVER` would have to be set to use a custom driver for JS tests, but then it would conflict with the `CAPYBARA_DRIVER` env variable for non-JS tests.

There are no other instances of `CAPYBARA_DRIVER` in this repo, and no related CI, so there's nothing else to update. However, this could be a breaking change for anybody depending on the existing env variable.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).