### PR TITLE
Paypal spec: Don't go via home page to product

### DIFF
--- a/spec/system/frontend/paypal_checkout_spec.rb
+++ b/spec/system/frontend/paypal_checkout_spec.rb
@@ -152,8 +152,7 @@ RSpec.describe "Checkout", type: :feature, js: true do
   end
 
   def add_mug_to_cart
-    visit root_path
-    click_link mug.name
+    visit product_path(mug)
     click_button "add-to-cart-button"
   end
 


### PR DESCRIPTION
We just need it in the cart and don't need to implicitly test the homepage.
