### PR TITLE
Fix load order issue with `table_name_prefix`

### DIFF
--- a/app/models/solidus_braintree/configuration.rb
+++ b/app/models/solidus_braintree/configuration.rb
@@ -2,6 +2,8 @@
 
 module SolidusBraintree
   class Configuration < ::Spree::Base
+    self.table_name = "solidus_paypal_braintree_configurations"
+
     PAYPAL_BUTTON_PREFERENCES = {
       color: { availables: %w[gold blue silver white black], default: 'white' },
       shape: { availables: %w[pill rect], default: 'rect' },

--- a/app/models/solidus_braintree/customer.rb
+++ b/app/models/solidus_braintree/customer.rb
@@ -2,6 +2,8 @@
 
 module SolidusBraintree
   class Customer < ApplicationRecord
+    self.table_name = "solidus_paypal_braintree_customers"
+
     belongs_to :user, class_name: ::Spree::UserClassHandle.new, optional: true
     has_many :sources, class_name: "SolidusBraintree::Source", inverse_of: :customer, dependent: :destroy
   end

--- a/app/models/solidus_braintree/source.rb
+++ b/app/models/solidus_braintree/source.rb
@@ -6,6 +6,8 @@ module SolidusBraintree
   class Source < ::Spree::PaymentSource
     include RequestProtection
 
+    self.table_name = "solidus_paypal_braintree_sources"
+
     PAYPAL = "PayPalAccount"
     APPLE_PAY = "ApplePayCard"
     VENMO = "VenmoAccount"

--- a/lib/solidus_braintree.rb
+++ b/lib/solidus_braintree.rb
@@ -10,7 +10,4 @@ require 'solidus_braintree/version'
 require 'solidus_braintree/engine'
 
 module SolidusBraintree
-  def self.table_name_prefix
-    'solidus_paypal_braintree_'
-  end
 end


### PR DESCRIPTION
## Summary

When running `bin/rails g solidus:install` and selecting `braintree` as
the payment method, there is currently a failure during the running of
the `db:seeds` task that points to an issue with the table prefix not
taking effect

```
ActiveRecord::StatementInvalid: Could not find table 'solidus_braintree_configurations' (ActiveRecord::StatementInvalid)
```

which comes from the store decorator here
```
app/decorators/models/solidus_braintree/spree_store_decorator.rb:14:in `build_default_configuration'
```

After some extensive testing, it seems like this is a load order issue
in development (autoloading enabled) where the definition needs to
happen before the engine is declared. The previous location of this
method happens after the `engine.rb` require.

We attempted to move this to `app/models/solidus_braintree.rb` however
that did not work either as the autoloader did not load that file at
all, likely because the namespace is already defined elsewhere.

The cleanest solution here seems to be to declare the table name in each
model as there are only 3 currently in the extension, so we've opted for
that.

## Steps to reproduce

1. `rails new my_store`
1. `bundle add solidus`
1. `bin/rails g solidus:install`
1. Select `braintree` as the payment method

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
