### PR TITLE
Move table_name_prefix to be a method in the parent module

### DIFF
--- a/app/models/solidus_braintree/base_record.rb
+++ b/app/models/solidus_braintree/base_record.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 module SolidusBraintree
+  def self.table_name_prefix
+    'solidus_paypal_braintree_'
+  end
+
   class BaseRecord < ::Spree::Base
     self.abstract_class = true
-    self.table_name_prefix = 'solidus_paypal_braintree_'
   end
 end

--- a/app/models/solidus_braintree/configuration.rb
+++ b/app/models/solidus_braintree/configuration.rb
@@ -2,8 +2,6 @@
 
 module SolidusBraintree
   class Configuration < BaseRecord
-    self.table_name = "solidus_paypal_braintree_configurations"
-
     PAYPAL_BUTTON_PREFERENCES = {
       color: { availables: %w[gold blue silver white black], default: 'white' },
       shape: { availables: %w[pill rect], default: 'rect' },


### PR DESCRIPTION
That's how this is supposed to work, apparently.
