### PR TITLE
Require braintree gem on startup

### DIFF
--- a/app/models/solidus_braintree/gateway.rb
+++ b/app/models/solidus_braintree/gateway.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'braintree'
 require 'solidus_braintree/request_protection'
 
 module SolidusBraintree

--- a/lib/solidus_braintree.rb
+++ b/lib/solidus_braintree.rb
@@ -2,6 +2,7 @@
 
 require 'solidus_core'
 require 'solidus_support'
+require 'braintree'
 
 require 'solidus_braintree/country_mapper'
 require 'solidus_braintree/request_protection'


### PR DESCRIPTION
If we put the `require` statement for the `braintree` gem into autoloadable code, the Braintree gem cannot be configured during startup. That's not great.
