### PR TITLE
Fix deprecated enum syntax

### DIFF
--- a/app/models/solidus_braintree/source.rb
+++ b/app/models/solidus_braintree/source.rb
@@ -13,11 +13,11 @@ module SolidusBraintree
     VENMO = "VenmoAccount"
     CREDIT_CARD = "CreditCard"
 
-    enum paypal_funding_source: {
+    enum :paypal_funding_source, {
       applepay: 0, bancontact: 1, blik: 2, boleto: 3, card: 4, credit: 5, eps: 6, giropay: 7, ideal: 8,
       itau: 9, maxima: 10, mercadopago: 11, mybank: 12, oxxo: 13, p24: 14, paylater: 15, paypal: 16, payu: 17,
       sepa: 18, sofort: 19, trustly: 20, venmo: 21, verkkopankki: 22, wechatpay: 23, zimpler: 24
-    }, _suffix: :funding
+    }, suffix: :funding
 
     belongs_to :user, class_name: ::Spree::UserClassHandle.new, optional: true
     belongs_to :payment_method, class_name: 'Spree::PaymentMethod'


### PR DESCRIPTION
## Summary

Fixes the following deprecation warning:

```
DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed
in Rails 8.0. Positional arguments should be used instead:

enum :paypal_funding_source, {applepay: 0, bancontact: 1, blik: 2, boleto: 3, card: 4, credit: 5, eps: 6, giropay: 7, ideal: 8, itau: 9, maxima: 10, mercadopago: 11, mybank: 12, oxxo: 13, p24: 14, paylater: 15, paypal: 16, payu: 17, sepa: 18, sofort: 19, trustly: 20, venmo: 21, verkkopankki: 22, wechatpay: 23, zimpler: 24}
 (called from <class:Source> at /Projects/.rvm/gems/ruby-3.4.1@cs_spree_3_0/bundler/gems/solidus_braintree-62b181e1c761/app/models/solidus_braintree/source.rb:14)
```

## Checklist

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).